### PR TITLE
Safe multiplication and division operations.

### DIFF
--- a/primal-sieve/src/wheel/mod.rs
+++ b/primal-sieve/src/wheel/mod.rs
@@ -14,7 +14,7 @@ pub fn small_for(x: usize) -> Option<BitVec> {
 }
 
 pub fn bits_for(x: usize) -> usize {
-    (x * BYTE_SIZE + BYTE_MODULO - 1) / BYTE_MODULO
+    (x.wrapping_mul(BYTE_SIZE).wrapping_add(BYTE_MODULO - 1)).wrapping_div(BYTE_MODULO)
 }
 
 pub fn bit_index(n: usize) -> (bool, usize) {


### PR DESCRIPTION
Just played around and accidentally catched an overflow in https://github.com/huonw/primal/blob/master/primal-sieve/src/wheel/mod.rs#L17

Sample code causing error:

    extern crate primal;
    use primal::Sieve;

    fn main() {
        let sieve = Sieve::new(10000000000000000000);
        let suspects:Vec<usize> = vec![1024, 5273, 1000000000000000007];
        for i in &suspects {
            let candidate = *i;
            match sieve.is_prime(candidate) {
                true => println!("{} is a prime!", candidate),
                false => println!("{} is not a prime =(", candidate)
            }
        }
    }

I'm new to Rust so probably it is not the best solution.