### PR TITLE
Sieve::factor: overflow fix and early-break optimization

### DIFF
--- a/primal-sieve/src/sieve.rs
+++ b/primal-sieve/src/sieve.rs
@@ -620,6 +620,24 @@ mod tests {
     }
 
     #[test]
+    fn factor_overflow() {
+        // if bound^2 overflows usize, we can factor any usize,
+        // but must take care to not hit overflow assertions.
+
+        // set up a limit that would overflow if naively squared, and a
+        // prime greater than that limit.  (these are more than double)
+        #[cfg(target_pointer_width = "32")]
+        const LIMIT_PRIME: (usize, usize) = (0x10000, 0x2001d);
+        #[cfg(target_pointer_width = "64")]
+        const LIMIT_PRIME: (usize, usize) = (0x100000000, 0x200000011);
+
+        let (limit, prime) = LIMIT_PRIME;
+        let primes = Sieve::new(limit);
+        assert!(prime > primes.upper_bound());
+        assert_eq!(primes.factor(prime), Ok(vec![(prime, 1)]));
+    }
+
+    #[test]
     fn factor_failures() {
         let primes = Sieve::new(30);
 

--- a/primal-sieve/src/sieve.rs
+++ b/primal-sieve/src/sieve.rs
@@ -257,16 +257,18 @@ impl Sieve {
         }
         if n != 1 {
             let b = self.upper_bound();
-            if b * b >= n {
-                // n is not divisible by anything from 1...sqrt(n), so
-                // must be prime itself! (That is, even though we
-                // don't know this prime specifically, we can infer
-                // that it must be prime.)
-                ret.push((n, 1));
-            } else {
-                // large factors :(
-                return Err((n, ret))
+            if let Some(bb) = b.checked_mul(b) {
+                if bb < n {
+                    // large factors :(
+                    return Err((n, ret))
+                }
             }
+
+            // n is not divisible by anything from 1...sqrt(n), so
+            // must be prime itself! (That is, even though we
+            // don't know this prime specifically, we can infer
+            // that it must be prime.)
+            ret.push((n, 1));
         }
         Ok(ret)
     }

--- a/primal-sieve/src/sieve.rs
+++ b/primal-sieve/src/sieve.rs
@@ -240,12 +240,11 @@ impl Sieve {
                                                  (usize, Vec<(usize, usize)>)>
     {
         if n == 0 { return Err((0, vec![])) }
+        if n == 1 { return Ok(vec![]) }
 
         let mut ret = Vec::new();
 
         for p in self.primes_from(0) {
-            if n == 1 { break }
-
             let mut count = 0;
             while n % p == 0 {
                 n /= p;
@@ -254,7 +253,13 @@ impl Sieve {
             if count > 0 {
                 ret.push((p,count));
             }
+
+            if let Some(pp) = p.checked_mul(p) {
+                if pp < n { continue }
+            }
+            break
         }
+
         if n != 1 {
             let b = self.upper_bound();
             if let Some(bb) = b.checked_mul(b) {

--- a/primal-sieve/src/sieve.rs
+++ b/primal-sieve/src/sieve.rs
@@ -710,6 +710,23 @@ mod benches {
     #[bench]
     fn prime_pi_huge(b: &mut Bencher) { prime_pi(b, 10_000_000) }
 
+    fn factor(b: &mut Bencher, n: usize) {
+        let s = Sieve::new(0x10000);
+
+        b.iter(|| s.factor(n).ok());
+    }
+
+    #[bench]
+    fn factor_small_prime(b: &mut Bencher) { factor(b, 131) }
+    #[bench]
+    fn factor_medium_prime(b: &mut Bencher) { factor(b, 7561) }
+    #[bench]
+    fn factor_large_prime(b: &mut Bencher) { factor(b, 65521) }
+    #[bench]
+    fn factor_over_prime(b: &mut Bencher) { factor(b, 1048573) }
+    #[bench]
+    fn factor_composite(b: &mut Bencher) { factor(b, 2*3*5*7*11*13*17*19) }
+
     fn bench_iterate(b: &mut Bencher, upto: usize) {
         let sieve = Sieve::new(upto);
 


### PR DESCRIPTION
This PR adds a fix for multiplication overflow, with a testcase that triggered it.
It also adds an early break when primes are too big to be a factor, with benchmarks.