### PR TITLE
Small optimisations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 rust:
   - nightly
   - beta
-  - 1.8.0
+  - 1.9.0
   - stable
 addons:
   apt:

--- a/primal-bit/src/lib.rs
+++ b/primal-bit/src/lib.rs
@@ -170,15 +170,8 @@ impl BitVec {
     /// }
     /// ```
     pub fn from_elem(nbits: usize, bit: bool) -> BitVec {
-        use std::ptr;
-
         let nblocks = nbits.checked_add(BITS - 1).expect("capacity overflow") / BITS;
-        let mut out_vec = Vec::with_capacity(nblocks);
-
-        unsafe {
-            out_vec.set_len(nblocks);
-            ptr::write_bytes(out_vec.as_mut_ptr(), if bit { !0 } else { 0 }, nblocks);
-        }
+        let out_vec = vec![if bit { !0 } else { 0 }; nblocks];
 
         let mut bit_vec = BitVec {
             storage: out_vec,

--- a/primal-bit/src/lib.rs
+++ b/primal-bit/src/lib.rs
@@ -15,7 +15,6 @@ extern crate hamming;
 use std::cmp::{self, Ordering};
 use std::fmt;
 use std::hash;
-use std::iter::repeat;
 use std::ops::Index;
 
 const BITS: usize = 64;
@@ -171,11 +170,21 @@ impl BitVec {
     /// }
     /// ```
     pub fn from_elem(nbits: usize, bit: bool) -> BitVec {
+        use std::ptr;
+
         let nblocks = nbits.checked_add(BITS - 1).expect("capacity overflow") / BITS;
+        let mut out_vec = Vec::with_capacity(nblocks);
+
+        unsafe {
+            out_vec.set_len(nblocks);
+            ptr::write_bytes(out_vec.as_mut_ptr(), if bit { !0 } else { 0 }, nblocks);
+        }
+
         let mut bit_vec = BitVec {
-            storage: repeat(if bit { !0 } else { 0 }).take(nblocks).collect(),
-            nbits: nbits
+            storage: out_vec,
+            nbits: nbits,
         };
+
         bit_vec.fix_last_block();
         bit_vec
     }

--- a/primal-sieve/Cargo.toml
+++ b/primal-sieve/Cargo.toml
@@ -16,7 +16,7 @@ A high performance prime sieve.
 [dependencies]
 primal-bit = { path = "../primal-bit", version = "0.2.2" }
 primal-estimate = { path = "../primal-estimate", version = "0.2" }
-
+smallvec = "0.4.1"
 hamming = "0.1"
 
 [dev-dependencies]

--- a/primal-sieve/src/lib.rs
+++ b/primal-sieve/src/lib.rs
@@ -10,6 +10,7 @@
 extern crate primal_bit;
 extern crate primal_estimate;
 extern crate hamming;
+extern crate smallvec;
 
 // black boxes for pointers; LLVM isn't so happy without
 // them. Unfortunately only usable with unstable, but the code isn't

--- a/primal-sieve/src/sieve.rs
+++ b/primal-sieve/src/sieve.rs
@@ -5,6 +5,8 @@ use hamming;
 
 use std::cmp;
 
+type SmallVec1<T> = ::smallvec::SmallVec<[T; 1]>;
+
 /// A heavily optimised prime sieve.
 ///
 /// This stores information about primes up to some specified limit,
@@ -30,7 +32,7 @@ use std::cmp;
 pub struct Sieve {
     seg_bits: usize,
     nbits: usize,
-    seen: Vec<Item>,
+    seen: SmallVec1<Item>,
 }
 
 #[derive(Debug)]
@@ -52,7 +54,7 @@ impl Sieve {
     /// Create a new instance, sieving out all the primes up to
     /// `limit`.
     pub fn new(limit: usize) -> Sieve {
-        let mut seen = Vec::new();
+        let mut seen = SmallVec1::new();
         let mut nbits = 0;
         let mut so_far = 0;
         let mut seg_bits = None;


### PR DESCRIPTION
These are only small improvements (`cargo benchcmp` tells me that small sieves get a boost of ~30%, medium a boost of ~15%, but huge sieves are more-or-less unaffected), but we use this in a hot part of code and so any small speed boost is a win. You're encouraged to benchmark on your own machine to verify the numbers I'm seeing. I do see a noticeable slowdown for `sieve_large` and `iterate_small`, I will rerun the benchmarks a few times each and see if those (and the improvements, of course) are consistent and then update this PR.

EDIT: So from running the benches 3 times before this PR and 3 times after, then running `cargo benchcmp` on the cross product of these results, it looks like none of the slowdowns are consistent and the `presieve`, `sieve`, `factor` and `iterate` speedups _are_ consistent. Score. Please do confirm this on your machine, however. I haven't tried the cross-product of each of these commits individually.