### PR TITLE
Clean up warnings and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 rust:
   - nightly
   - beta
-  - 1.0.0
+  - 1.8.0
   - stable
 addons:
   apt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ primal-sieve = { path = "primal-sieve", version = "0.2" }
 
 [dev-dependencies]
 primal-slowsieve = { path = "primal-slowsieve", version = "0.2" }
-time = "0.1"
+time = "0.1, <=0.1.37" # 0.1.38 doesn't work with rust 1.8
 
 [features]
 unstable = ["primal-sieve/unstable"]

--- a/examples/small_prime_props.rs
+++ b/examples/small_prime_props.rs
@@ -51,7 +51,7 @@ fn main() {
         let len = text.len();
         let mut new_prime = true;
 
-        for _ in (last..p) {
+        for _ in last..p {
             if check_width!(1 + len) && !new_prime {
                 print!(" ");
                 width += 1

--- a/primal-check/Cargo.toml
+++ b/primal-check/Cargo.toml
@@ -14,7 +14,7 @@ Fast standalone primality testing.
 """
 
 [dependencies]
-num = "0"
+num-integer = "0.1"
 
 [dev-dependencies]
 primal = { path = "..", version = "0.2" }

--- a/primal-check/src/lib.rs
+++ b/primal-check/src/lib.rs
@@ -1,7 +1,7 @@
 //! Check some primality-related properties of numbers.
 //!
 //! This crate is designed to be used via `primal`.
-extern crate num;
+extern crate num_integer;
 #[cfg(test)]
 extern crate primal;
 

--- a/primal-check/src/perfect_power.rs
+++ b/primal-check/src/perfect_power.rs
@@ -1,4 +1,4 @@
-use num::Integer;
+use num_integer::Integer;
 
 fn wrapping_pow(mut base: u64, mut exp: u32) -> u64 {
     let mut acc: u64 = 1;
@@ -135,7 +135,7 @@ mod tests {
             // include 1 to test p itself.
             for (q, is_prime) in Some((1, true)).into_iter().chain(subprimes) {
                 let pq = p * q as u64;
-                for n in (1..MAX.log(pq as f64) as u32) {
+                for n in 1..(MAX.log(pq as f64) as u32) {
                     let x = pq.pow(n);
 
                     let expected = (pq, n as u8);

--- a/primal-sieve/src/sieve.rs
+++ b/primal-sieve/src/sieve.rs
@@ -684,7 +684,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "cannot sieve upto"]
+    #[should_panic(expected = "cannot sieve upto")]
     fn too_large() {
         // with a wheel size of 30, this would take more bits than fit
         // in a usize.

--- a/primal-sieve/src/streaming/presieve.rs
+++ b/primal-sieve/src/streaming/presieve.rs
@@ -104,7 +104,7 @@ mod benches {
     use test::Bencher;
     use super::Presieve;
     fn run_presieve(b: &mut Bencher, n: usize) {
-        b.iter(|| super::Presieve::new(::wheel::bits_for(n)))
+        b.iter(|| Presieve::new(::wheel::bits_for(n)))
     }
     #[bench]
     fn presieve_small(b: &mut Bencher) {

--- a/primal-sieve/src/streaming/primes.rs
+++ b/primal-sieve/src/streaming/primes.rs
@@ -8,10 +8,6 @@ const ITER_BASE_STEP: usize = 8 * wheel::BYTE_MODULO;
 const SQRT: usize = 1 << 16;
 #[cfg(target_pointer_width = "64")]
 const SQRT: usize = 1 << 32;
-#[cfg(target_pointer_width = "32")]
-type Queued = u16;
-#[cfg(target_pointer_width = "64")]
-type Queued = u32;
 
 enum Early {
     Two,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@
 //! This takes 6 <em>micro</em>seconds: more than 500,000&times;
 //! faster than the iterator!
 
-#![cfg_attr(all(test, feature = "unstable"), feature(test, step_by))]
+#![cfg_attr(all(test, feature = "unstable"), feature(test, iterator_step_by))]
 
 extern crate primal_estimate;
 extern crate primal_check;


### PR DESCRIPTION
- warning: unnecessary parentheses around `for` head expression
- warning: type alias is never used: `Queued`
- warning: unused import: `super::Presieve`
- warning: attribute must be of the form: `#[should_panic]` or
  `#[should_panic(expected = "error message")]`
- error: use of unstable library feature 'iterator_step_by': unstable
  replacement of Range::step_by
- Narrow `num` to just `num-integer`
- Update minimum CI to 1.8.0 as `num` crates require