### PR TITLE
Test primal on i686

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,17 @@ after_success:
 
 notifications:
     webhooks: http://huon.me:54856/travis
+
+matrix:
+  include:
+    - rust: nightly
+      env: TARGET='i686-unknown-linux-gnu'
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+      before_script:
+        - rustup target add $TARGET
+        - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+      script:
+        - ./run-in all travis-cargo test -- --target $TARGET

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,13 @@ time = "0.1, <=0.1.37" # 0.1.38 doesn't work with rust 1.8
 
 [features]
 unstable = ["primal-sieve/unstable"]
+
+[workspace]
+members = [
+    "primal-bit",
+    "primal-check",
+    "primal-estimate",
+    "primal-sieve",
+    "primal-slowsieve",
+    "wheel-generator",
+]

--- a/primal-sieve/src/streaming/primes.rs
+++ b/primal-sieve/src/streaming/primes.rs
@@ -61,7 +61,7 @@ impl Primes {
 
     fn sqrt(sqrt: usize) -> Primes {
         let (sieving, limit) = if sqrt < streaming::isqrt(streaming::SEG_LEN) {
-            (None, sqrt)
+            (None, sqrt * sqrt)
         } else {
             (Some(Box::new(Primes::sqrt(streaming::isqrt(sqrt)))),
              streaming::SEG_LEN)


### PR DESCRIPTION
Locally, I found that some tests were failing on i686, so it seems like a good idea to add this to CI.

There was an error in the upper bound of the nested `Primes` sieve, which was only seen on i686 just because the equivalent breaking point on x86_64 was much higher than people realistically use it for.