### PR TITLE
sieve: Remove internal limits

### DIFF
--- a/primal-sieve/src/streaming/mod.rs
+++ b/primal-sieve/src/streaming/mod.rs
@@ -258,8 +258,8 @@ impl StreamingSieve {
         }
 
         let low = self.low;
-        self.low += SEG_LEN;
-        let high = cmp::min(low + SEG_LEN - 1, self.limit);
+        self.low = self.low.saturating_add(SEG_LEN);
+        let high = cmp::min(low.saturating_add(SEG_LEN - 1), self.limit);
 
         self.find_new_sieving_primes(low, high);
 

--- a/primal-sieve/src/streaming/primes.rs
+++ b/primal-sieve/src/streaming/primes.rs
@@ -119,10 +119,10 @@ impl Iterator for Primes {
                 }
             }
             let low = self.streaming.low;
-            let high = low + streaming::SEG_LEN;
+            let high = low.saturating_add(streaming::SEG_LEN);
 
             for q in self.left_over.into_iter().chain(self.sieving_primes.as_mut().unwrap()) {
-                if q * q > high {
+                if q.saturating_mul(q) >= high {
                     self.left_over = Some(q);
                     break
                 }
@@ -151,9 +151,7 @@ mod tests {
     use Sieve;
     use super::Primes;
 
-    #[test]
-    fn equality() {
-        let limit = 20_000_000;
+    fn check_equality(limit: usize) {
         let sieve = Sieve::new(limit);
 
         let real = sieve.primes_from(0).take_while(|x| *x < limit);
@@ -165,6 +163,17 @@ mod tests {
             i += 1;
         }
         assert_eq!(sieve.prime_pi(limit), i);
+    }
+
+    #[test]
+    fn equality() {
+        check_equality(20_000_000);
+    }
+
+    #[test]
+    fn equality_huge() {
+        // This takes a minute or so in debug mode, but it does work!
+        check_equality(::std::u32::MAX as usize);
     }
 }
 

--- a/primal-sieve/src/wheel/mod.rs
+++ b/primal-sieve/src/wheel/mod.rs
@@ -23,12 +23,11 @@ pub fn small_for(x: usize) -> Option<BitVec> {
 }
 
 pub fn bits_for(x: usize) -> usize {
-    use std::usize;
-    let limit = (usize::MAX - BYTE_MODULO + 1) / BYTE_SIZE;
-    assert!(x < limit,
-            "cannot sieve upto {}, which is larger than {}",
-            x, limit);
-    (x * BYTE_SIZE + BYTE_MODULO - 1) / BYTE_MODULO
+    // ceil((x * BYTE_SIZE) / BYTE_MODULO)
+    // computed using the remainder to avoid overflow
+    let d = x / BYTE_MODULO;
+    let r = x % BYTE_MODULO;
+    d * BYTE_SIZE + (r * BYTE_SIZE + BYTE_MODULO - 1) / BYTE_MODULO
 }
 
 pub fn bit_index(n: usize) -> (bool, usize) {
@@ -47,12 +46,21 @@ pub fn bit_index(n: usize) -> (bool, usize) {
     let init = &POS[n % BYTE_MODULO];
     (init.0, (n / BYTE_MODULO) * BYTE_SIZE + init.1 as usize)
 }
+
+pub fn upper_bound(nbits: usize) -> usize {
+    // basically from_bit_index(nbits)-1, but without overflow
+    (nbits / BYTE_SIZE).checked_mul(BYTE_MODULO)
+        .and_then(|n| n.checked_add(TRUE_AT_BIT[nbits % BYTE_SIZE] - 1))
+        .unwrap_or(::std::usize::MAX)
+}
+
 pub fn from_bit_index(bit: usize) -> usize {
-    const TRUE_AT_BIT: &'static [usize; 8] = &[
-        1, 7, 11, 13, 17, 19, 23, 29
-            ];
     (bit / BYTE_SIZE) * BYTE_MODULO + TRUE_AT_BIT[bit % BYTE_SIZE]
 }
+
+const TRUE_AT_BIT: &'static [usize; 8] = &[
+    1, 7, 11, 13, 17, 19, 23, 29
+        ];
 
 pub const TRUE_AT_BIT_64: &'static [usize; 64] = &[
     1 + 30*0, 7 + 30*0, 11 + 30*0, 13 + 30*0, 17 + 30*0, 19 + 30*0, 23 + 30*0, 29 + 30*0,


### PR DESCRIPTION
You want to sieve all the way up to `usize::MAX`?  You got it!  At
least, that's been tested on i686 -- I don't have enough time or memory
to let a 64-bit platform go on a full run...

Performance looks pretty stable.  For the most part, the added care
about overflows is not in performance critical areas.