### PR TITLE
check: bump to 0.2.3

### DIFF
--- a/primal-check/Cargo.toml
+++ b/primal-check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-check"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 
 homepage = "https://github.com/huonw/primal"


### PR DESCRIPTION
This allows publication to crates.io of a new version of primal-check with narrower
declared dependencies (introduced in 324cb05758e7b8cd5a314fdc2841394db2775572).

Before this commit, users of primal would pull in primal-check 0.2.2, which would pull
in all of num 0.x, which in turn would include quite old versions of rand, libc, and
rustc-serialize which are not supported on the webassembly targets.

After this commit, primal is able to be used with webassembly targets. A new version of
primal-check must be published for this to take effect for public users.