### PR TITLE
Add codecov.yml to ignore the generators subdirectory.

### DIFF
--- a/ci/codecov.yml
+++ b/ci/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        paths: "!generators/"


### PR DESCRIPTION
These generators are "tested" via their generated code and its tests,
and don't/won't get run as part of the testsuite.