### PR TITLE
Version shenanigans for cyclic dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "primal"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "primal"
-version = "0.3.0"
+version = "0.2.3"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 

--- a/primal-check/Cargo.toml
+++ b/primal-check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-check"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ Fast standalone primality testing.
 num-integer = "0.1"
 
 [dev-dependencies]
-primal = { path = "..", version = "0.2" }
+primal = { path = "..", version = "0.3" }
 
 [features]
 unstable = []

--- a/primal-check/Cargo.toml
+++ b/primal-check/Cargo.toml
@@ -18,7 +18,7 @@ Fast standalone primality testing.
 num-integer = "0.1"
 
 [dev-dependencies]
-primal = { path = "..", version = "0.3" }
+primal = { path = "..", version = "0.2" }
 
 [features]
 unstable = []

--- a/primal-estimate/Cargo.toml
+++ b/primal-estimate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-estimate"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ State-of-the-art estimation of upper and lower bounds for π(n)
 """
 
 [dev-dependencies]
-primal = { path = "..", version = "0.2" }
+primal = { path = "..", version = "0.3" }
 
 [features]
 unstable = []

--- a/primal-estimate/Cargo.toml
+++ b/primal-estimate/Cargo.toml
@@ -15,7 +15,7 @@ State-of-the-art estimation of upper and lower bounds for π(n)
 """
 
 [dev-dependencies]
-primal = { path = "..", version = "0.3" }
+primal = { path = "..", version = "0.2" }
 
 [features]
 unstable = []

--- a/primal-sieve/Cargo.toml
+++ b/primal-sieve/Cargo.toml
@@ -21,7 +21,7 @@ smallvec = "1"
 
 [dev-dependencies]
 primal-slowsieve = { path = "../primal-slowsieve", version = "0.3" }
-primal = { path = "..", version = "0.3" }
+primal = { path = "..", version = "0.2" }
 criterion = "0.3"
 
 [[bench]]

--- a/primal-sieve/Cargo.toml
+++ b/primal-sieve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-sieve"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ smallvec = "1"
 
 [dev-dependencies]
 primal-slowsieve = { path = "../primal-slowsieve", version = "0.3" }
-primal = { path = "..", version = "0.2" }
+primal = { path = "..", version = "0.3" }
 criterion = "0.3"
 
 [[bench]]


### PR DESCRIPTION
I had to temporarily reset the primal version to publish some of the sub-crates, and then I bumped it all back in sync. But branch protection won't let me push this without bors, so here we go...

bors merge