### PR TITLE
primal-sieve: Avoid UB use of `pointer::offset`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ primal-sieve = { path = "primal-sieve", version = "0.3" }
 
 [dev-dependencies]
 primal-slowsieve = { path = "primal-slowsieve", version = "0.3" }
-criterion = "0.3"
+criterion = { version = "0.3.4", features = ["html_reports"] }
 
 [[bench]]
 name = "bench"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,39 +1,36 @@
 #[macro_use]
 extern crate criterion;
-use criterion::{Criterion, Fun};
+use criterion::Criterion;
 
 const N: usize = 1_000_000;
 const STEP: usize = 101;
 
 fn is_prime(c: &mut Criterion) {
-    let miller_rabin = Fun::new(
-        "is_prime",
-        |b, _| {
-            b.iter(|| (1..N).step_by(STEP).filter(|&n| primal::is_prime(n as u64)).count())
-        });
-    let sieve = Fun::new(
-        "Sieve::is_prime",
-        |b, _| {
-            let sieve = primal::Sieve::new(N);
-            b.iter(|| {
-                (1..N).step_by(STEP)
-                    .filter(|&n| sieve.is_prime(n)).count()
-            })
-        });
-    let sieve_with_init = Fun::new(
-        "Sieve::is_prime with init",
-        |b, _| {
-            b.iter(|| {
-                let sieve = primal::Sieve::new(N);
-                (1..N).step_by(STEP)
-                    .filter(|&n| sieve.is_prime(n)).count()
-            })
-        });
+    let mut group = c.benchmark_group("is_prime");
 
-    c.bench_functions(
-        "is_prime", vec![miller_rabin, sieve, sieve_with_init], ());
+    group.bench_function("is_prime", |b| {
+        b.iter(|| {
+            (1..N)
+                .step_by(STEP)
+                .filter(|&n| primal::is_prime(n as u64))
+                .count()
+        })
+    });
+
+    group.bench_function("Sieve::is_prime", |b| {
+        let sieve = primal::Sieve::new(N);
+        b.iter(|| (1..N).step_by(STEP).filter(|&n| sieve.is_prime(n)).count())
+    });
+
+    group.bench_function("Sieve::is_prime with init", |b| {
+        b.iter(|| {
+            let sieve = primal::Sieve::new(N);
+            (1..N).step_by(STEP).filter(|&n| sieve.is_prime(n)).count()
+        })
+    });
+
+    group.finish();
 }
 
 criterion_group!(benches, is_prime);
 criterion_main!(benches);
-

--- a/generators/src/bin/wheel-generator.rs
+++ b/generators/src/bin/wheel-generator.rs
@@ -263,8 +263,8 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
 
         for info in cur_infos {
             println!("\
-{indent}    safe_assert!(start <= p.offset(prime_ * {sl} + {off}) &&
-{indent}                 p.offset(prime_ * {sl} + {off}) < end);
+{indent}    safe_assert!(start <= p.wrapping_offset(prime_ * {sl} + {off}) &&
+{indent}                 p.wrapping_offset(prime_ * {sl} + {off}) < end);
 {indent}    *p.offset(prime_ * {sl} + {off}) &= {bit};",
                      // p starts at offset 1 * prime_, so strip off
                      // that factor.
@@ -273,7 +273,7 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                      bit = info.unset_bit, indent = indent);
         }
         println!("
-{indent}    p = p.offset(prime_ * {} + {})
+{indent}    p = (p as usize).saturating_add(prime * {} + {}) as *mut u8;
 {indent}}}",
                  wheel, c,
                  indent = indent);
@@ -288,7 +288,7 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
             println!("\
 {indent} if p >= end {{ wi = {val}; break 'outer; }}
 {indent} safe_assert!(start <= p && p < end);
-{indent} *p &= {}; p = p.offset(prime_ * {} + {});
+{indent} *p &= {}; p = (p as usize).saturating_add(prime * {} + {}) as *mut u8;
 {indent} {}
 {indent}}}",
 

--- a/primal-sieve/Cargo.toml
+++ b/primal-sieve/Cargo.toml
@@ -22,7 +22,7 @@ smallvec = "1"
 [dev-dependencies]
 primal-slowsieve = { path = "../primal-slowsieve", version = "0.3" }
 primal = { path = "..", version = "0.3" }
-criterion = "0.3"
+criterion = { version = "0.3.4", features = ["html_reports"] }
 
 [[bench]]
 name = "bench"

--- a/primal-sieve/Cargo.toml
+++ b/primal-sieve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-sieve"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 

--- a/primal-sieve/benches/bench.rs
+++ b/primal-sieve/benches/bench.rs
@@ -1,26 +1,30 @@
 #[macro_use]
 extern crate criterion;
 
-use primal_sieve::{StreamingSieve, Sieve, Primes};
-use criterion::{Criterion, ParameterizedBenchmark};
+use criterion::{BenchmarkId, Criterion};
+use primal_sieve::{Primes, Sieve, StreamingSieve};
 
 const SIZES: [usize; 5] = [100, 10_000, 100_000, 1_000_000, 10_000_000];
 
 macro_rules! create_benchmarks {
     ($(
         fn $group_id: ident($input: expr) {
-            $first_name: expr => $first_func: expr,
-            $($rest_name: expr => $rest_func: expr,)*
+            $($name: expr => $func: expr,)*
         }
     )*) => {
         $(
             fn $group_id(c: &mut Criterion) {
                 let input = $input;
+                let mut group = c.benchmark_group(stringify!($group_id));
 
-                let bench = ParameterizedBenchmark::new(
-                    $first_name, $first_func, input.iter().copied())
-                    $( .with_function($rest_name, $rest_func) )*;
-                c.bench(stringify!($group_id), bench);
+                $(
+                    for i in &input {
+                        let id = BenchmarkId::new($name, i);
+                        group.bench_with_input(id, i, $func);
+                    }
+                )*
+
+                group.finish();
             }
         )*
     }

--- a/primal-sieve/src/streaming/primes.rs
+++ b/primal-sieve/src/streaming/primes.rs
@@ -220,7 +220,7 @@ mod tests {
         // will take too long, but we can cut it short by unwinding.
         Primes::all().fold((), |(), p| {
             if p > 123456789 {
-                panic!(format!("{}", p));
+                panic!("{}", p);
             }
         })
     }

--- a/primal-sieve/src/wheel/wheel210.rs
+++ b/primal-sieve/src/wheel/wheel210.rs
@@ -938,246 +938,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 0) < end);
                                                                 *p.offset(prime_ * 208 + 0) &= 127;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 1) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 1);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 0; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 254; p = (p as usize).saturating_add(prime * 10 + 0) as *mut u8;
+                                                            *p &= 254;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 0);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label1
                                                            }
                                                            if p >= end { wi = 1; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                                           *p &= 251;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label2
                                                           }
                                                           if p >= end { wi = 2; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                                          *p &= 247;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label3
                                                          }
                                                          if p >= end { wi = 3; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                                         *p &= 239;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label4
                                                         }
                                                         if p >= end { wi = 4; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                                        *p &= 223;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label5
                                                        }
                                                        if p >= end { wi = 5; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                                       *p &= 191;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label6
                                                       }
                                                       if p >= end { wi = 6; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 127;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label7
                                                      }
                                                      if p >= end { wi = 7; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                                     *p &= 254;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label8
                                                     }
                                                     if p >= end { wi = 8; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                                    *p &= 253;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label9
                                                    }
                                                    if p >= end { wi = 9; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                                   *p &= 251;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label10
                                                   }
                                                   if p >= end { wi = 10; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                                  *p &= 247;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label11
                                                  }
                                                  if p >= end { wi = 11; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 239; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                                 *p &= 239;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label12
                                                 }
                                                 if p >= end { wi = 12; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                                *p &= 191;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label13
                                                }
                                                if p >= end { wi = 13; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 127;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label14
                                               }
                                               if p >= end { wi = 14; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                              *p &= 254;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label15
                                              }
                                              if p >= end { wi = 15; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                             *p &= 253;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label16
                                             }
                                             if p >= end { wi = 16; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                            *p &= 251;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label17
                                            }
                                            if p >= end { wi = 17; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 247; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                           *p &= 247;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label18
                                           }
                                           if p >= end { wi = 18; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                          *p &= 223;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label19
                                          }
                                          if p >= end { wi = 19; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                         *p &= 191;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label20
                                         }
                                         if p >= end { wi = 20; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 127; p = (p as usize).saturating_add(prime * 8 + 1) as *mut u8;
+                                        *p &= 127;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 1);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label21
                                        }
                                        if p >= end { wi = 21; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                       *p &= 253;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label22
                                       }
                                       if p >= end { wi = 22; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                      *p &= 251;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label23
                                      }
                                      if p >= end { wi = 23; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                     *p &= 247;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label24
                                     }
                                     if p >= end { wi = 24; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                    *p &= 239;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label25
                                    }
                                    if p >= end { wi = 25; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                   *p &= 223;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label26
                                   }
                                   if p >= end { wi = 26; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 191; p = (p as usize).saturating_add(prime * 8 + 1) as *mut u8;
+                                  *p &= 191;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 1);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label27
                                  }
                                  if p >= end { wi = 27; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                                 *p &= 254;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label28
                                 }
                                 if p >= end { wi = 28; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                *p &= 253;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label29
                                }
                                if p >= end { wi = 29; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 251; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                               *p &= 251;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label30
                               }
                               if p >= end { wi = 30; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                              *p &= 239;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label31
                              }
                              if p >= end { wi = 31; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                             *p &= 223;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label32
                             }
                             if p >= end { wi = 32; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                            *p &= 191;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label33
                            }
                            if p >= end { wi = 33; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 127;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label34
                           }
                           if p >= end { wi = 34; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                          *p &= 254;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label35
                          }
                          if p >= end { wi = 35; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 253; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                         *p &= 253;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label36
                         }
                         if p >= end { wi = 36; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                        *p &= 247;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label37
                        }
                        if p >= end { wi = 37; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                       *p &= 239;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label38
                       }
                       if p >= end { wi = 38; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                      *p &= 223;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label39
                      }
                      if p >= end { wi = 39; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                     *p &= 191;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label40
                     }
                     if p >= end { wi = 40; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 127;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label41
                    }
                    if p >= end { wi = 41; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                   *p &= 254;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label42
                   }
                   if p >= end { wi = 42; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                  *p &= 253;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label43
                  }
                  if p >= end { wi = 43; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                 *p &= 251;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label44
                 }
                 if p >= end { wi = 44; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                *p &= 247;
+                let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                p = if p <= p2 { p2 } else { end };
                 break 'label45
                }
                if p >= end { wi = 45; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+               *p &= 239;
+               let p2 = p.wrapping_offset(prime_ * 2 + 0);
+               p = if p <= p2 { p2 } else { end };
                break 'label46
               }
               if p >= end { wi = 46; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 223; p = (p as usize).saturating_add(prime * 10 + 0) as *mut u8;
+              *p &= 223;
+              let p2 = p.wrapping_offset(prime_ * 10 + 0);
+              p = if p <= p2 { p2 } else { end };
               break 'label47
              }
              if p >= end { wi = 47; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 127;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 0
             }
         }
@@ -1429,246 +1526,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 6) < end);
                                                                 *p.offset(prime_ * 208 + 6) &= 191;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 11) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 11);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 48; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 253; p = (p as usize).saturating_add(prime * 10 + 2) as *mut u8;
+                                                            *p &= 253;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 2);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label49
                                                            }
                                                            if p >= end { wi = 49; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                           *p &= 239;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label50
                                                           }
                                                           if p >= end { wi = 50; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                                          *p &= 254;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label51
                                                          }
                                                          if p >= end { wi = 51; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                         *p &= 127;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label52
                                                         }
                                                         if p >= end { wi = 52; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                                        *p &= 247;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label53
                                                        }
                                                        if p >= end { wi = 53; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                                                       *p &= 251;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label54
                                                       }
                                                       if p >= end { wi = 54; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 191;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label55
                                                      }
                                                      if p >= end { wi = 55; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                                                     *p &= 253;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label56
                                                     }
                                                     if p >= end { wi = 56; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                                    *p &= 223;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label57
                                                    }
                                                    if p >= end { wi = 57; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                   *p &= 239;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label58
                                                   }
                                                   if p >= end { wi = 58; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                                  *p &= 254;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label59
                                                  }
                                                  if p >= end { wi = 59; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 127; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                                 *p &= 127;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label60
                                                 }
                                                 if p >= end { wi = 60; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                                                *p &= 251;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label61
                                                }
                                                if p >= end { wi = 61; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 191;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label62
                                               }
                                               if p >= end { wi = 62; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                                              *p &= 253;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label63
                                              }
                                              if p >= end { wi = 63; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                             *p &= 223;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label64
                                             }
                                             if p >= end { wi = 64; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                            *p &= 239;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label65
                                            }
                                            if p >= end { wi = 65; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 254; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                                           *p &= 254;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label66
                                           }
                                           if p >= end { wi = 66; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                          *p &= 247;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label67
                                          }
                                          if p >= end { wi = 67; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                                         *p &= 251;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label68
                                         }
                                         if p >= end { wi = 68; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 191; p = (p as usize).saturating_add(prime * 8 + 2) as *mut u8;
+                                        *p &= 191;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 2);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label69
                                        }
                                        if p >= end { wi = 69; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                       *p &= 223;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label70
                                       }
                                       if p >= end { wi = 70; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                      *p &= 239;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label71
                                      }
                                      if p >= end { wi = 71; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                                     *p &= 254;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label72
                                     }
                                     if p >= end { wi = 72; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                    *p &= 127;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label73
                                    }
                                    if p >= end { wi = 73; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                   *p &= 247;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label74
                                   }
                                   if p >= end { wi = 74; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 251; p = (p as usize).saturating_add(prime * 8 + 2) as *mut u8;
+                                  *p &= 251;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 2);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label75
                                  }
                                  if p >= end { wi = 75; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                                 *p &= 253;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label76
                                 }
                                 if p >= end { wi = 76; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                *p &= 223;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label77
                                }
                                if p >= end { wi = 77; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 239; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                               *p &= 239;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label78
                               }
                               if p >= end { wi = 78; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                              *p &= 127;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label79
                              }
                              if p >= end { wi = 79; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                             *p &= 247;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label80
                             }
                             if p >= end { wi = 80; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                            *p &= 251;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label81
                            }
                            if p >= end { wi = 81; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 191;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label82
                           }
                           if p >= end { wi = 82; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                          *p &= 253;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label83
                          }
                          if p >= end { wi = 83; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 223; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                         *p &= 223;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label84
                         }
                         if p >= end { wi = 84; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                        *p &= 254;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label85
                        }
                        if p >= end { wi = 85; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                       *p &= 127;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label86
                       }
                       if p >= end { wi = 86; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                      *p &= 247;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label87
                      }
                      if p >= end { wi = 87; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                     *p &= 251;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label88
                     }
                     if p >= end { wi = 88; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 191;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label89
                    }
                    if p >= end { wi = 89; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                   *p &= 253;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label90
                   }
                   if p >= end { wi = 90; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                  *p &= 223;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label91
                  }
                  if p >= end { wi = 91; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                 *p &= 239;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label92
                 }
                 if p >= end { wi = 92; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                *p &= 254;
+                let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                p = if p <= p2 { p2 } else { end };
                 break 'label93
                }
                if p >= end { wi = 93; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+               *p &= 127;
+               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+               p = if p <= p2 { p2 } else { end };
                break 'label94
               }
               if p >= end { wi = 94; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 247; p = (p as usize).saturating_add(prime * 10 + 2) as *mut u8;
+              *p &= 247;
+              let p2 = p.wrapping_offset(prime_ * 10 + 2);
+              p = if p <= p2 { p2 } else { end };
               break 'label95
              }
              if p >= end { wi = 95; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 191;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 48
             }
         }
@@ -1920,246 +2114,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 10) < end);
                                                                 *p.offset(prime_ * 208 + 10) &= 223;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 13) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 13);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 96; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 251; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
+                                                            *p &= 251;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 4);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label97
                                                            }
                                                            if p >= end { wi = 97; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                                           *p &= 254;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label98
                                                           }
                                                           if p >= end { wi = 98; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                          *p &= 191;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label99
                                                          }
                                                          if p >= end { wi = 99; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                                         *p &= 253;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label100
                                                         }
                                                         if p >= end { wi = 100; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                        *p &= 127;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label101
                                                        }
                                                        if p >= end { wi = 101; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                                       *p &= 247;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label102
                                                       }
                                                       if p >= end { wi = 102; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 223;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label103
                                                      }
                                                      if p >= end { wi = 103; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                                     *p &= 251;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label104
                                                     }
                                                     if p >= end { wi = 104; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                    *p &= 239;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label105
                                                    }
                                                    if p >= end { wi = 105; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                                   *p &= 254;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label106
                                                   }
                                                   if p >= end { wi = 106; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                  *p &= 191;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label107
                                                  }
                                                  if p >= end { wi = 107; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 253; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                                 *p &= 253;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label108
                                                 }
                                                 if p >= end { wi = 108; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                                *p &= 247;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label109
                                                }
                                                if p >= end { wi = 109; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 223;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label110
                                               }
                                               if p >= end { wi = 110; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                              *p &= 251;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label111
                                              }
                                              if p >= end { wi = 111; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                             *p &= 239;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label112
                                             }
                                             if p >= end { wi = 112; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                            *p &= 254;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label113
                                            }
                                            if p >= end { wi = 113; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 191; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                           *p &= 191;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label114
                                           }
                                           if p >= end { wi = 114; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                          *p &= 127;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label115
                                          }
                                          if p >= end { wi = 115; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                         *p &= 247;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label116
                                         }
                                         if p >= end { wi = 116; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 223; p = (p as usize).saturating_add(prime * 8 + 3) as *mut u8;
+                                        *p &= 223;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 3);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label117
                                        }
                                        if p >= end { wi = 117; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                       *p &= 239;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label118
                                       }
                                       if p >= end { wi = 118; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                      *p &= 254;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label119
                                      }
                                      if p >= end { wi = 119; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                     *p &= 191;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label120
                                     }
                                     if p >= end { wi = 120; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                                    *p &= 253;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label121
                                    }
                                    if p >= end { wi = 121; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                   *p &= 127;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label122
                                   }
                                   if p >= end { wi = 122; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 247; p = (p as usize).saturating_add(prime * 8 + 3) as *mut u8;
+                                  *p &= 247;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 3);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label123
                                  }
                                  if p >= end { wi = 123; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                 *p &= 251;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label124
                                 }
                                 if p >= end { wi = 124; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                *p &= 239;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label125
                                }
                                if p >= end { wi = 125; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 254; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                               *p &= 254;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label126
                               }
                               if p >= end { wi = 126; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                              *p &= 253;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label127
                              }
                              if p >= end { wi = 127; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                             *p &= 127;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label128
                             }
                             if p >= end { wi = 128; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                            *p &= 247;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label129
                            }
                            if p >= end { wi = 129; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 223;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label130
                           }
                           if p >= end { wi = 130; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                          *p &= 251;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label131
                          }
                          if p >= end { wi = 131; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 239; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                         *p &= 239;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label132
                         }
                         if p >= end { wi = 132; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                        *p &= 191;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label133
                        }
                        if p >= end { wi = 133; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                       *p &= 253;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label134
                       }
                       if p >= end { wi = 134; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                      *p &= 127;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label135
                      }
                      if p >= end { wi = 135; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                     *p &= 247;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label136
                     }
                     if p >= end { wi = 136; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 223;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label137
                    }
                    if p >= end { wi = 137; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                   *p &= 251;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label138
                   }
                   if p >= end { wi = 138; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                  *p &= 239;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label139
                  }
                  if p >= end { wi = 139; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                 *p &= 254;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label140
                 }
                 if p >= end { wi = 140; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                *p &= 191;
+                let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                p = if p <= p2 { p2 } else { end };
                 break 'label141
                }
                if p >= end { wi = 141; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+               *p &= 253;
+               let p2 = p.wrapping_offset(prime_ * 2 + 0);
+               p = if p <= p2 { p2 } else { end };
                break 'label142
               }
               if p >= end { wi = 142; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 127; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
+              *p &= 127;
+              let p2 = p.wrapping_offset(prime_ * 10 + 4);
+              p = if p <= p2 { p2 } else { end };
               break 'label143
              }
              if p >= end { wi = 143; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 223;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 96
             }
         }
@@ -2411,246 +2702,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 12) < end);
                                                                 *p.offset(prime_ * 208 + 12) &= 239;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 17) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 17);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 144; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 247; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
+                                                            *p &= 247;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 4);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label145
                                                            }
                                                            if p >= end { wi = 145; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                           *p &= 191;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label146
                                                           }
                                                           if p >= end { wi = 146; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                          *p &= 223;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label147
                                                          }
                                                          if p >= end { wi = 147; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                         *p &= 251;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label148
                                                         }
                                                         if p >= end { wi = 148; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                                        *p &= 253;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label149
                                                        }
                                                        if p >= end { wi = 149; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                                       *p &= 127;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label150
                                                       }
                                                       if p >= end { wi = 150; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 239;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label151
                                                      }
                                                      if p >= end { wi = 151; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                                     *p &= 247;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label152
                                                     }
                                                     if p >= end { wi = 152; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                                    *p &= 254;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label153
                                                    }
                                                    if p >= end { wi = 153; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                   *p &= 191;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label154
                                                   }
                                                   if p >= end { wi = 154; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                  *p &= 223;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label155
                                                  }
                                                  if p >= end { wi = 155; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                                                 *p &= 251;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label156
                                                 }
                                                 if p >= end { wi = 156; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                                *p &= 127;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label157
                                                }
                                                if p >= end { wi = 157; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 239;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label158
                                               }
                                               if p >= end { wi = 158; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                              *p &= 247;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label159
                                              }
                                              if p >= end { wi = 159; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                             *p &= 254;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label160
                                             }
                                             if p >= end { wi = 160; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                            *p &= 191;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label161
                                            }
                                            if p >= end { wi = 161; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 223; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                           *p &= 223;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label162
                                           }
                                           if p >= end { wi = 162; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                          *p &= 253;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label163
                                          }
                                          if p >= end { wi = 163; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                         *p &= 127;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label164
                                         }
                                         if p >= end { wi = 164; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 239; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
+                                        *p &= 239;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 4);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label165
                                        }
                                        if p >= end { wi = 165; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                       *p &= 254;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label166
                                       }
                                       if p >= end { wi = 166; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                      *p &= 191;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label167
                                      }
                                      if p >= end { wi = 167; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                     *p &= 223;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label168
                                     }
                                     if p >= end { wi = 168; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                    *p &= 251;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label169
                                    }
                                    if p >= end { wi = 169; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                   *p &= 253;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label170
                                   }
                                   if p >= end { wi = 170; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 127; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
+                                  *p &= 127;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 4);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label171
                                  }
                                  if p >= end { wi = 171; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                 *p &= 247;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label172
                                 }
                                 if p >= end { wi = 172; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                                *p &= 254;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label173
                                }
                                if p >= end { wi = 173; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 191; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                               *p &= 191;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label174
                               }
                               if p >= end { wi = 174; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                              *p &= 251;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label175
                              }
                              if p >= end { wi = 175; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                             *p &= 253;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label176
                             }
                             if p >= end { wi = 176; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                            *p &= 127;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label177
                            }
                            if p >= end { wi = 177; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 239;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label178
                           }
                           if p >= end { wi = 178; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                          *p &= 247;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label179
                          }
                          if p >= end { wi = 179; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 254; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                         *p &= 254;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label180
                         }
                         if p >= end { wi = 180; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                        *p &= 223;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label181
                        }
                        if p >= end { wi = 181; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                       *p &= 251;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label182
                       }
                       if p >= end { wi = 182; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                      *p &= 253;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label183
                      }
                      if p >= end { wi = 183; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                     *p &= 127;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label184
                     }
                     if p >= end { wi = 184; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 239;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label185
                    }
                    if p >= end { wi = 185; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                   *p &= 247;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label186
                   }
                   if p >= end { wi = 186; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                  *p &= 254;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label187
                  }
                  if p >= end { wi = 187; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                 *p &= 191;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label188
                 }
                 if p >= end { wi = 188; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                *p &= 223;
+                let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                p = if p <= p2 { p2 } else { end };
                 break 'label189
                }
                if p >= end { wi = 189; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+               *p &= 251;
+               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+               p = if p <= p2 { p2 } else { end };
                break 'label190
               }
               if p >= end { wi = 190; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 253; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
+              *p &= 253;
+              let p2 = p.wrapping_offset(prime_ * 10 + 4);
+              p = if p <= p2 { p2 } else { end };
               break 'label191
              }
              if p >= end { wi = 191; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 239;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 144
             }
         }
@@ -2902,246 +3290,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 16) < end);
                                                                 *p.offset(prime_ * 208 + 16) &= 247;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 19) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 19);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 192; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 239; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
+                                                            *p &= 239;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 6);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label193
                                                            }
                                                            if p >= end { wi = 193; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                           *p &= 253;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label194
                                                           }
                                                           if p >= end { wi = 194; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                          *p &= 251;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label195
                                                          }
                                                          if p >= end { wi = 195; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                         *p &= 223;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label196
                                                         }
                                                         if p >= end { wi = 196; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                                        *p &= 191;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label197
                                                        }
                                                        if p >= end { wi = 197; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                                       *p &= 254;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label198
                                                       }
                                                       if p >= end { wi = 198; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 247;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label199
                                                      }
                                                      if p >= end { wi = 199; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                                     *p &= 239;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label200
                                                     }
                                                     if p >= end { wi = 200; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                                    *p &= 127;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label201
                                                    }
                                                    if p >= end { wi = 201; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                   *p &= 253;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label202
                                                   }
                                                   if p >= end { wi = 202; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                  *p &= 251;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label203
                                                  }
                                                  if p >= end { wi = 203; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                                 *p &= 223;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label204
                                                 }
                                                 if p >= end { wi = 204; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                                *p &= 254;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label205
                                                }
                                                if p >= end { wi = 205; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 247;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label206
                                               }
                                               if p >= end { wi = 206; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                              *p &= 239;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label207
                                              }
                                              if p >= end { wi = 207; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                             *p &= 127;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label208
                                             }
                                             if p >= end { wi = 208; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                            *p &= 253;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label209
                                            }
                                            if p >= end { wi = 209; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 251; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                           *p &= 251;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label210
                                           }
                                           if p >= end { wi = 210; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                          *p &= 191;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label211
                                          }
                                          if p >= end { wi = 211; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                         *p &= 254;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label212
                                         }
                                         if p >= end { wi = 212; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 247; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
+                                        *p &= 247;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 4);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label213
                                        }
                                        if p >= end { wi = 213; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                       *p &= 127;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label214
                                       }
                                       if p >= end { wi = 214; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                      *p &= 253;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label215
                                      }
                                      if p >= end { wi = 215; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                     *p &= 251;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label216
                                     }
                                     if p >= end { wi = 216; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                    *p &= 223;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label217
                                    }
                                    if p >= end { wi = 217; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                   *p &= 191;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label218
                                   }
                                   if p >= end { wi = 218; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 254; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
+                                  *p &= 254;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 4);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label219
                                  }
                                  if p >= end { wi = 219; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                                 *p &= 239;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label220
                                 }
                                 if p >= end { wi = 220; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                *p &= 127;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label221
                                }
                                if p >= end { wi = 221; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 253; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                               *p &= 253;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label222
                               }
                               if p >= end { wi = 222; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                              *p &= 223;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label223
                              }
                              if p >= end { wi = 223; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                             *p &= 191;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label224
                             }
                             if p >= end { wi = 224; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                            *p &= 254;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label225
                            }
                            if p >= end { wi = 225; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 247;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label226
                           }
                           if p >= end { wi = 226; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                          *p &= 239;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label227
                          }
                          if p >= end { wi = 227; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 127; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                         *p &= 127;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label228
                         }
                         if p >= end { wi = 228; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                        *p &= 251;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label229
                        }
                        if p >= end { wi = 229; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                       *p &= 223;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label230
                       }
                       if p >= end { wi = 230; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                      *p &= 191;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label231
                      }
                      if p >= end { wi = 231; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                     *p &= 254;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label232
                     }
                     if p >= end { wi = 232; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 247;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label233
                    }
                    if p >= end { wi = 233; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                   *p &= 239;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label234
                   }
                   if p >= end { wi = 234; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                  *p &= 127;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label235
                  }
                  if p >= end { wi = 235; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                 *p &= 253;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label236
                 }
                 if p >= end { wi = 236; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                *p &= 251;
+                let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                p = if p <= p2 { p2 } else { end };
                 break 'label237
                }
                if p >= end { wi = 237; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+               *p &= 223;
+               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+               p = if p <= p2 { p2 } else { end };
                break 'label238
               }
               if p >= end { wi = 238; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 191; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
+              *p &= 191;
+              let p2 = p.wrapping_offset(prime_ * 10 + 6);
+              p = if p <= p2 { p2 } else { end };
               break 'label239
              }
              if p >= end { wi = 239; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 247;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 192
             }
         }
@@ -3393,246 +3878,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 18) < end);
                                                                 *p.offset(prime_ * 208 + 18) &= 251;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 23) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 23);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 240; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 223; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
+                                                            *p &= 223;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 6);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label241
                                                            }
                                                            if p >= end { wi = 241; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                                           *p &= 127;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label242
                                                           }
                                                           if p >= end { wi = 242; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                          *p &= 253;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label243
                                                          }
                                                          if p >= end { wi = 243; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                                         *p &= 191;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label244
                                                         }
                                                         if p >= end { wi = 244; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                        *p &= 254;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label245
                                                        }
                                                        if p >= end { wi = 245; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                                       *p &= 239;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label246
                                                       }
                                                       if p >= end { wi = 246; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 251;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label247
                                                      }
                                                      if p >= end { wi = 247; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                                     *p &= 223;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label248
                                                     }
                                                     if p >= end { wi = 248; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                    *p &= 247;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label249
                                                    }
                                                    if p >= end { wi = 249; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                                   *p &= 127;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label250
                                                   }
                                                   if p >= end { wi = 250; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                                  *p &= 253;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label251
                                                  }
                                                  if p >= end { wi = 251; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 191; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                                 *p &= 191;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label252
                                                 }
                                                 if p >= end { wi = 252; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                                *p &= 239;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label253
                                                }
                                                if p >= end { wi = 253; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 251;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label254
                                               }
                                               if p >= end { wi = 254; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                              *p &= 223;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label255
                                              }
                                              if p >= end { wi = 255; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                             *p &= 247;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label256
                                             }
                                             if p >= end { wi = 256; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                            *p &= 127;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label257
                                            }
                                            if p >= end { wi = 257; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 253; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                           *p &= 253;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label258
                                           }
                                           if p >= end { wi = 258; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                          *p &= 254;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label259
                                          }
                                          if p >= end { wi = 259; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                         *p &= 239;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label260
                                         }
                                         if p >= end { wi = 260; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 251; p = (p as usize).saturating_add(prime * 8 + 5) as *mut u8;
+                                        *p &= 251;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 5);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label261
                                        }
                                        if p >= end { wi = 261; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                       *p &= 247;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label262
                                       }
                                       if p >= end { wi = 262; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                      *p &= 127;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label263
                                      }
                                      if p >= end { wi = 263; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                     *p &= 253;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label264
                                     }
                                     if p >= end { wi = 264; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                    *p &= 191;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label265
                                    }
                                    if p >= end { wi = 265; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                   *p &= 254;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label266
                                   }
                                   if p >= end { wi = 266; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 239; p = (p as usize).saturating_add(prime * 8 + 5) as *mut u8;
+                                  *p &= 239;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 5);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label267
                                  }
                                  if p >= end { wi = 267; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                 *p &= 223;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label268
                                 }
                                 if p >= end { wi = 268; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                                *p &= 247;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label269
                                }
                                if p >= end { wi = 269; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 127; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                               *p &= 127;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label270
                               }
                               if p >= end { wi = 270; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                              *p &= 191;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label271
                              }
                              if p >= end { wi = 271; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                             *p &= 254;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label272
                             }
                             if p >= end { wi = 272; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                            *p &= 239;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label273
                            }
                            if p >= end { wi = 273; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 251;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label274
                           }
                           if p >= end { wi = 274; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                          *p &= 223;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label275
                          }
                          if p >= end { wi = 275; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 247; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                         *p &= 247;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label276
                         }
                         if p >= end { wi = 276; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                        *p &= 253;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label277
                        }
                        if p >= end { wi = 277; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                       *p &= 191;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label278
                       }
                       if p >= end { wi = 278; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                      *p &= 254;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label279
                      }
                      if p >= end { wi = 279; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                     *p &= 239;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label280
                     }
                     if p >= end { wi = 280; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 251;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label281
                    }
                    if p >= end { wi = 281; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                   *p &= 223;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label282
                   }
                   if p >= end { wi = 282; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                  *p &= 247;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label283
                  }
                  if p >= end { wi = 283; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                 *p &= 127;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label284
                 }
                 if p >= end { wi = 284; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                *p &= 253;
+                let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                p = if p <= p2 { p2 } else { end };
                 break 'label285
                }
                if p >= end { wi = 285; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+               *p &= 191;
+               let p2 = p.wrapping_offset(prime_ * 2 + 2);
+               p = if p <= p2 { p2 } else { end };
                break 'label286
               }
               if p >= end { wi = 286; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 254; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
+              *p &= 254;
+              let p2 = p.wrapping_offset(prime_ * 10 + 6);
+              p = if p <= p2 { p2 } else { end };
               break 'label287
              }
              if p >= end { wi = 287; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 251;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 240
             }
         }
@@ -3884,246 +4466,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 22) < end);
                                                                 *p.offset(prime_ * 208 + 22) &= 253;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 29) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 29);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 288; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 191; p = (p as usize).saturating_add(prime * 10 + 8) as *mut u8;
+                                                            *p &= 191;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 8);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label289
                                                            }
                                                            if p >= end { wi = 289; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                           *p &= 247;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label290
                                                           }
                                                           if p >= end { wi = 290; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                                          *p &= 127;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label291
                                                          }
                                                          if p >= end { wi = 291; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                         *p &= 254;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label292
                                                         }
                                                         if p >= end { wi = 292; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                                        *p &= 239;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label293
                                                        }
                                                        if p >= end { wi = 293; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                                                       *p &= 223;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label294
                                                       }
                                                       if p >= end { wi = 294; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 253;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label295
                                                      }
                                                      if p >= end { wi = 295; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                                                     *p &= 191;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label296
                                                     }
                                                     if p >= end { wi = 296; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                                    *p &= 251;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label297
                                                    }
                                                    if p >= end { wi = 297; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                   *p &= 247;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label298
                                                   }
                                                   if p >= end { wi = 298; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                                  *p &= 127;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label299
                                                  }
                                                  if p >= end { wi = 299; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 254; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                                                 *p &= 254;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label300
                                                 }
                                                 if p >= end { wi = 300; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                                                *p &= 223;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label301
                                                }
                                                if p >= end { wi = 301; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 253;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label302
                                               }
                                               if p >= end { wi = 302; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                                              *p &= 191;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label303
                                              }
                                              if p >= end { wi = 303; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                             *p &= 251;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label304
                                             }
                                             if p >= end { wi = 304; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                            *p &= 247;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label305
                                            }
                                            if p >= end { wi = 305; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 127; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                                           *p &= 127;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label306
                                           }
                                           if p >= end { wi = 306; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                          *p &= 239;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label307
                                          }
                                          if p >= end { wi = 307; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                                         *p &= 223;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label308
                                         }
                                         if p >= end { wi = 308; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 253; p = (p as usize).saturating_add(prime * 8 + 6) as *mut u8;
+                                        *p &= 253;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 6);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label309
                                        }
                                        if p >= end { wi = 309; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                       *p &= 251;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label310
                                       }
                                       if p >= end { wi = 310; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                      *p &= 247;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label311
                                      }
                                      if p >= end { wi = 311; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                     *p &= 127;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label312
                                     }
                                     if p >= end { wi = 312; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                    *p &= 254;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label313
                                    }
                                    if p >= end { wi = 313; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                   *p &= 239;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label314
                                   }
                                   if p >= end { wi = 314; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 223; p = (p as usize).saturating_add(prime * 8 + 6) as *mut u8;
+                                  *p &= 223;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 6);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label315
                                  }
                                  if p >= end { wi = 315; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                                 *p &= 191;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label316
                                 }
                                 if p >= end { wi = 316; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                                *p &= 251;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label317
                                }
                                if p >= end { wi = 317; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 247; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                               *p &= 247;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label318
                               }
                               if p >= end { wi = 318; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                              *p &= 254;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label319
                              }
                              if p >= end { wi = 319; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                             *p &= 239;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label320
                             }
                             if p >= end { wi = 320; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                            *p &= 223;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label321
                            }
                            if p >= end { wi = 321; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 253;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label322
                           }
                           if p >= end { wi = 322; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                          *p &= 191;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label323
                          }
                          if p >= end { wi = 323; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 251; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                         *p &= 251;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label324
                         }
                         if p >= end { wi = 324; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                        *p &= 127;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label325
                        }
                        if p >= end { wi = 325; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                       *p &= 254;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label326
                       }
                       if p >= end { wi = 326; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                      *p &= 239;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label327
                      }
                      if p >= end { wi = 327; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                     *p &= 223;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label328
                     }
                     if p >= end { wi = 328; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 253;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label329
                    }
                    if p >= end { wi = 329; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                   *p &= 191;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label330
                   }
                   if p >= end { wi = 330; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                  *p &= 251;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label331
                  }
                  if p >= end { wi = 331; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                 *p &= 247;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label332
                 }
                 if p >= end { wi = 332; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                *p &= 127;
+                let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                p = if p <= p2 { p2 } else { end };
                 break 'label333
                }
                if p >= end { wi = 333; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+               *p &= 254;
+               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+               p = if p <= p2 { p2 } else { end };
                break 'label334
               }
               if p >= end { wi = 334; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 239; p = (p as usize).saturating_add(prime * 10 + 8) as *mut u8;
+              *p &= 239;
+              let p2 = p.wrapping_offset(prime_ * 10 + 8);
+              p = if p <= p2 { p2 } else { end };
               break 'label335
              }
              if p >= end { wi = 335; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 253;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 288
             }
         }
@@ -4375,246 +5054,343 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                                              p.wrapping_offset(prime_ * 208 + 28) < end);
                                                                 *p.offset(prime_ * 208 + 28) &= 254;
 
-                                                                p = (p as usize).saturating_add(prime * 210 + 31) as *mut u8;
+                                                                let p2 = p.wrapping_offset(prime_ * 210 + 31);
+                                                                p = if p <= p2 { p2 } else { end };
                                                             }
                                                             if p >= end { wi = 336; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 127; p = (p as usize).saturating_add(prime * 10 + 10) as *mut u8;
+                                                            *p &= 127;
+                                                            let p2 = p.wrapping_offset(prime_ * 10 + 10);
+                                                            p = if p <= p2 { p2 } else { end };
                                                             break 'label337
                                                            }
                                                            if p >= end { wi = 337; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                                           *p &= 223;
+                                                           let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                                           p = if p <= p2 { p2 } else { end };
                                                            break 'label338
                                                           }
                                                           if p >= end { wi = 338; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                                          *p &= 239;
+                                                          let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                                          p = if p <= p2 { p2 } else { end };
                                                           break 'label339
                                                          }
                                                          if p >= end { wi = 339; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                                         *p &= 247;
+                                                         let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                                         p = if p <= p2 { p2 } else { end };
                                                          break 'label340
                                                         }
                                                         if p >= end { wi = 340; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                                        *p &= 251;
+                                                        let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                                        p = if p <= p2 { p2 } else { end };
                                                         break 'label341
                                                        }
                                                        if p >= end { wi = 341; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                                       *p &= 253;
+                                                       let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                                       p = if p <= p2 { p2 } else { end };
                                                        break 'label342
                                                       }
                                                       if p >= end { wi = 342; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                                      *p &= 254;
+                                                      let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                                      p = if p <= p2 { p2 } else { end };
                                                       break 'label343
                                                      }
                                                      if p >= end { wi = 343; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                                     *p &= 127;
+                                                     let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                                     p = if p <= p2 { p2 } else { end };
                                                      break 'label344
                                                     }
                                                     if p >= end { wi = 344; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                                    *p &= 191;
+                                                    let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                                    p = if p <= p2 { p2 } else { end };
                                                     break 'label345
                                                    }
                                                    if p >= end { wi = 345; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                                   *p &= 223;
+                                                   let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                                   p = if p <= p2 { p2 } else { end };
                                                    break 'label346
                                                   }
                                                   if p >= end { wi = 346; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                                  *p &= 239;
+                                                  let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                                  p = if p <= p2 { p2 } else { end };
                                                   break 'label347
                                                  }
                                                  if p >= end { wi = 347; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 247; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                                 *p &= 247;
+                                                 let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                                 p = if p <= p2 { p2 } else { end };
                                                  break 'label348
                                                 }
                                                 if p >= end { wi = 348; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                                *p &= 253;
+                                                let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                                p = if p <= p2 { p2 } else { end };
                                                 break 'label349
                                                }
                                                if p >= end { wi = 349; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                                               *p &= 254;
+                                               let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                                               p = if p <= p2 { p2 } else { end };
                                                break 'label350
                                               }
                                               if p >= end { wi = 350; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                              *p &= 127;
+                                              let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                              p = if p <= p2 { p2 } else { end };
                                               break 'label351
                                              }
                                              if p >= end { wi = 351; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                             *p &= 191;
+                                             let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                             p = if p <= p2 { p2 } else { end };
                                              break 'label352
                                             }
                                             if p >= end { wi = 352; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                            *p &= 223;
+                                            let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                            p = if p <= p2 { p2 } else { end };
                                             break 'label353
                                            }
                                            if p >= end { wi = 353; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 239; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                           *p &= 239;
+                                           let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                           p = if p <= p2 { p2 } else { end };
                                            break 'label354
                                           }
                                           if p >= end { wi = 354; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                          *p &= 251;
+                                          let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                          p = if p <= p2 { p2 } else { end };
                                           break 'label355
                                          }
                                          if p >= end { wi = 355; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                         *p &= 253;
+                                         let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                         p = if p <= p2 { p2 } else { end };
                                          break 'label356
                                         }
                                         if p >= end { wi = 356; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 254; p = (p as usize).saturating_add(prime * 8 + 7) as *mut u8;
+                                        *p &= 254;
+                                        let p2 = p.wrapping_offset(prime_ * 8 + 7);
+                                        p = if p <= p2 { p2 } else { end };
                                         break 'label357
                                        }
                                        if p >= end { wi = 357; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                       *p &= 191;
+                                       let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                       p = if p <= p2 { p2 } else { end };
                                        break 'label358
                                       }
                                       if p >= end { wi = 358; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                      *p &= 223;
+                                      let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                      p = if p <= p2 { p2 } else { end };
                                       break 'label359
                                      }
                                      if p >= end { wi = 359; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                     *p &= 239;
+                                     let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                     p = if p <= p2 { p2 } else { end };
                                      break 'label360
                                     }
                                     if p >= end { wi = 360; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                                    *p &= 247;
+                                    let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                                    p = if p <= p2 { p2 } else { end };
                                     break 'label361
                                    }
                                    if p >= end { wi = 361; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                   *p &= 251;
+                                   let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                   p = if p <= p2 { p2 } else { end };
                                    break 'label362
                                   }
                                   if p >= end { wi = 362; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 253; p = (p as usize).saturating_add(prime * 8 + 7) as *mut u8;
+                                  *p &= 253;
+                                  let p2 = p.wrapping_offset(prime_ * 8 + 7);
+                                  p = if p <= p2 { p2 } else { end };
                                   break 'label363
                                  }
                                  if p >= end { wi = 363; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                                 *p &= 127;
+                                 let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                                 p = if p <= p2 { p2 } else { end };
                                  break 'label364
                                 }
                                 if p >= end { wi = 364; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                                *p &= 191;
+                                let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                                p = if p <= p2 { p2 } else { end };
                                 break 'label365
                                }
                                if p >= end { wi = 365; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 223; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                               *p &= 223;
+                               let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                               p = if p <= p2 { p2 } else { end };
                                break 'label366
                               }
                               if p >= end { wi = 366; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                              *p &= 247;
+                              let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                              p = if p <= p2 { p2 } else { end };
                               break 'label367
                              }
                              if p >= end { wi = 367; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                             *p &= 251;
+                             let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                             p = if p <= p2 { p2 } else { end };
                              break 'label368
                             }
                             if p >= end { wi = 368; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                            *p &= 253;
+                            let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                            p = if p <= p2 { p2 } else { end };
                             break 'label369
                            }
                            if p >= end { wi = 369; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                           *p &= 254;
+                           let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                           p = if p <= p2 { p2 } else { end };
                            break 'label370
                           }
                           if p >= end { wi = 370; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                          *p &= 127;
+                          let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                          p = if p <= p2 { p2 } else { end };
                           break 'label371
                          }
                          if p >= end { wi = 371; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 191; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                         *p &= 191;
+                         let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                         p = if p <= p2 { p2 } else { end };
                          break 'label372
                         }
                         if p >= end { wi = 372; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                        *p &= 239;
+                        let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                        p = if p <= p2 { p2 } else { end };
                         break 'label373
                        }
                        if p >= end { wi = 373; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                       *p &= 247;
+                       let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                       p = if p <= p2 { p2 } else { end };
                        break 'label374
                       }
                       if p >= end { wi = 374; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                      *p &= 251;
+                      let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                      p = if p <= p2 { p2 } else { end };
                       break 'label375
                      }
                      if p >= end { wi = 375; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                     *p &= 253;
+                     let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                     p = if p <= p2 { p2 } else { end };
                      break 'label376
                     }
                     if p >= end { wi = 376; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                    *p &= 254;
+                    let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label377
                    }
                    if p >= end { wi = 377; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                   *p &= 127;
+                   let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label378
                   }
                   if p >= end { wi = 378; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                  *p &= 191;
+                  let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label379
                  }
                  if p >= end { wi = 379; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                 *p &= 223;
+                 let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label380
                 }
                 if p >= end { wi = 380; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                *p &= 239;
+                let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                p = if p <= p2 { p2 } else { end };
                 break 'label381
                }
                if p >= end { wi = 381; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+               *p &= 247;
+               let p2 = p.wrapping_offset(prime_ * 2 + 2);
+               p = if p <= p2 { p2 } else { end };
                break 'label382
               }
               if p >= end { wi = 382; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 251; p = (p as usize).saturating_add(prime * 10 + 10) as *mut u8;
+              *p &= 251;
+              let p2 = p.wrapping_offset(prime_ * 10 + 10);
+              p = if p <= p2 { p2 } else { end };
               break 'label383
              }
              if p >= end { wi = 383; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 254;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 336
             }
         }

--- a/primal-sieve/src/wheel/wheel210.rs
+++ b/primal-sieve/src/wheel/wheel210.rs
@@ -793,391 +793,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 0) &&
-                                                                             p.offset(prime_ * 10 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 0) < end);
                                                                 *p.offset(prime_ * 10 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 0) &&
-                                                                             p.offset(prime_ * 12 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 0) < end);
                                                                 *p.offset(prime_ * 12 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 0) &&
-                                                                             p.offset(prime_ * 16 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 0) < end);
                                                                 *p.offset(prime_ * 16 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 0) &&
-                                                                             p.offset(prime_ * 18 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 0) < end);
                                                                 *p.offset(prime_ * 18 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 0) &&
-                                                                             p.offset(prime_ * 22 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 0) < end);
                                                                 *p.offset(prime_ * 22 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 0) &&
-                                                                             p.offset(prime_ * 28 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 0) < end);
                                                                 *p.offset(prime_ * 28 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 0) &&
-                                                                             p.offset(prime_ * 30 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 0) < end);
                                                                 *p.offset(prime_ * 30 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 0) &&
-                                                                             p.offset(prime_ * 36 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 0) < end);
                                                                 *p.offset(prime_ * 36 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 0) &&
-                                                                             p.offset(prime_ * 40 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 0) < end);
                                                                 *p.offset(prime_ * 40 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 0) &&
-                                                                             p.offset(prime_ * 42 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 0) < end);
                                                                 *p.offset(prime_ * 42 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 0) &&
-                                                                             p.offset(prime_ * 46 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 0) < end);
                                                                 *p.offset(prime_ * 46 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 0) &&
-                                                                             p.offset(prime_ * 52 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 0) < end);
                                                                 *p.offset(prime_ * 52 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 0) &&
-                                                                             p.offset(prime_ * 58 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 0) < end);
                                                                 *p.offset(prime_ * 58 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 0) &&
-                                                                             p.offset(prime_ * 60 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 0) < end);
                                                                 *p.offset(prime_ * 60 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 0) &&
-                                                                             p.offset(prime_ * 66 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 0) < end);
                                                                 *p.offset(prime_ * 66 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 0) &&
-                                                                             p.offset(prime_ * 70 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 0) < end);
                                                                 *p.offset(prime_ * 70 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 0) &&
-                                                                             p.offset(prime_ * 72 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 0) < end);
                                                                 *p.offset(prime_ * 72 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 0) &&
-                                                                             p.offset(prime_ * 78 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 0) < end);
                                                                 *p.offset(prime_ * 78 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 0) &&
-                                                                             p.offset(prime_ * 82 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 0) < end);
                                                                 *p.offset(prime_ * 82 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 0) &&
-                                                                             p.offset(prime_ * 88 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 0) < end);
                                                                 *p.offset(prime_ * 88 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 0) &&
-                                                                             p.offset(prime_ * 96 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 0) < end);
                                                                 *p.offset(prime_ * 96 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 0) &&
-                                                                             p.offset(prime_ * 100 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 0) < end);
                                                                 *p.offset(prime_ * 100 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 0) &&
-                                                                             p.offset(prime_ * 102 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 0) < end);
                                                                 *p.offset(prime_ * 102 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 0) &&
-                                                                             p.offset(prime_ * 106 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 0) < end);
                                                                 *p.offset(prime_ * 106 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 0) &&
-                                                                             p.offset(prime_ * 108 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 0) < end);
                                                                 *p.offset(prime_ * 108 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 0) &&
-                                                                             p.offset(prime_ * 112 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 0) < end);
                                                                 *p.offset(prime_ * 112 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 0) &&
-                                                                             p.offset(prime_ * 120 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 0) < end);
                                                                 *p.offset(prime_ * 120 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 0) &&
-                                                                             p.offset(prime_ * 126 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 0) < end);
                                                                 *p.offset(prime_ * 126 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 0) &&
-                                                                             p.offset(prime_ * 130 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 0) < end);
                                                                 *p.offset(prime_ * 130 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 0) &&
-                                                                             p.offset(prime_ * 136 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 0) < end);
                                                                 *p.offset(prime_ * 136 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 0) &&
-                                                                             p.offset(prime_ * 138 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 0) < end);
                                                                 *p.offset(prime_ * 138 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 0) &&
-                                                                             p.offset(prime_ * 142 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 0) < end);
                                                                 *p.offset(prime_ * 142 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 0) &&
-                                                                             p.offset(prime_ * 148 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 0) < end);
                                                                 *p.offset(prime_ * 148 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 0) &&
-                                                                             p.offset(prime_ * 150 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 0) < end);
                                                                 *p.offset(prime_ * 150 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 0) &&
-                                                                             p.offset(prime_ * 156 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 0) < end);
                                                                 *p.offset(prime_ * 156 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 0) &&
-                                                                             p.offset(prime_ * 162 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 0) < end);
                                                                 *p.offset(prime_ * 162 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 0) &&
-                                                                             p.offset(prime_ * 166 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 0) < end);
                                                                 *p.offset(prime_ * 166 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 0) &&
-                                                                             p.offset(prime_ * 168 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 0) < end);
                                                                 *p.offset(prime_ * 168 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 0) &&
-                                                                             p.offset(prime_ * 172 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 0) < end);
                                                                 *p.offset(prime_ * 172 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 0) &&
-                                                                             p.offset(prime_ * 178 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 0) < end);
                                                                 *p.offset(prime_ * 178 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 0) &&
-                                                                             p.offset(prime_ * 180 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 0) < end);
                                                                 *p.offset(prime_ * 180 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 0) &&
-                                                                             p.offset(prime_ * 186 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 0) < end);
                                                                 *p.offset(prime_ * 186 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 0) &&
-                                                                             p.offset(prime_ * 190 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 0) < end);
                                                                 *p.offset(prime_ * 190 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 0) &&
-                                                                             p.offset(prime_ * 192 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 0) < end);
                                                                 *p.offset(prime_ * 192 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 0) &&
-                                                                             p.offset(prime_ * 196 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 0) < end);
                                                                 *p.offset(prime_ * 196 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 0) &&
-                                                                             p.offset(prime_ * 198 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 0) < end);
                                                                 *p.offset(prime_ * 198 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 0) &&
-                                                                             p.offset(prime_ * 208 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 0) < end);
                                                                 *p.offset(prime_ * 208 + 0) &= 127;
 
-                                                                p = p.offset(prime_ * 210 + 1)
+                                                                p = (p as usize).saturating_add(prime * 210 + 1) as *mut u8;
                                                             }
                                                             if p >= end { wi = 0; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 254; p = p.offset(prime_ * 10 + 0);
+                                                            *p &= 254; p = (p as usize).saturating_add(prime * 10 + 0) as *mut u8;
                                                             break 'label1
                                                            }
                                                            if p >= end { wi = 1; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 251; p = p.offset(prime_ * 2 + 0);
+                                                           *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                                            break 'label2
                                                           }
                                                           if p >= end { wi = 2; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 247; p = p.offset(prime_ * 4 + 0);
+                                                          *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                                           break 'label3
                                                          }
                                                          if p >= end { wi = 3; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 239; p = p.offset(prime_ * 2 + 0);
+                                                         *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                                          break 'label4
                                                         }
                                                         if p >= end { wi = 4; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 223; p = p.offset(prime_ * 4 + 0);
+                                                        *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                                         break 'label5
                                                        }
                                                        if p >= end { wi = 5; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 191; p = p.offset(prime_ * 6 + 0);
+                                                       *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                                        break 'label6
                                                       }
                                                       if p >= end { wi = 6; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 127; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label7
                                                      }
                                                      if p >= end { wi = 7; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 254; p = p.offset(prime_ * 6 + 0);
+                                                     *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                                      break 'label8
                                                     }
                                                     if p >= end { wi = 8; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 253; p = p.offset(prime_ * 4 + 0);
+                                                    *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                                     break 'label9
                                                    }
                                                    if p >= end { wi = 9; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 251; p = p.offset(prime_ * 2 + 0);
+                                                   *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                                    break 'label10
                                                   }
                                                   if p >= end { wi = 10; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 247; p = p.offset(prime_ * 4 + 0);
+                                                  *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                                   break 'label11
                                                  }
                                                  if p >= end { wi = 11; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 239; p = p.offset(prime_ * 6 + 0);
+                                                 *p &= 239; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                                  break 'label12
                                                 }
                                                 if p >= end { wi = 12; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 191; p = p.offset(prime_ * 6 + 0);
+                                                *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                                 break 'label13
                                                }
                                                if p >= end { wi = 13; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 127; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label14
                                               }
                                               if p >= end { wi = 14; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 254; p = p.offset(prime_ * 6 + 0);
+                                              *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                               break 'label15
                                              }
                                              if p >= end { wi = 15; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 253; p = p.offset(prime_ * 4 + 0);
+                                             *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                              break 'label16
                                             }
                                             if p >= end { wi = 16; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 251; p = p.offset(prime_ * 2 + 0);
+                                            *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                             break 'label17
                                            }
                                            if p >= end { wi = 17; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 247; p = p.offset(prime_ * 6 + 0);
+                                           *p &= 247; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                            break 'label18
                                           }
                                           if p >= end { wi = 18; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 223; p = p.offset(prime_ * 4 + 0);
+                                          *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                           break 'label19
                                          }
                                          if p >= end { wi = 19; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 191; p = p.offset(prime_ * 6 + 0);
+                                         *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                          break 'label20
                                         }
                                         if p >= end { wi = 20; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 127; p = p.offset(prime_ * 8 + 1);
+                                        *p &= 127; p = (p as usize).saturating_add(prime * 8 + 1) as *mut u8;
                                         break 'label21
                                        }
                                        if p >= end { wi = 21; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 253; p = p.offset(prime_ * 4 + 0);
+                                       *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                        break 'label22
                                       }
                                       if p >= end { wi = 22; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 251; p = p.offset(prime_ * 2 + 0);
+                                      *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                       break 'label23
                                      }
                                      if p >= end { wi = 23; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 247; p = p.offset(prime_ * 4 + 0);
+                                     *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                      break 'label24
                                     }
                                     if p >= end { wi = 24; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 239; p = p.offset(prime_ * 2 + 0);
+                                    *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                     break 'label25
                                    }
                                    if p >= end { wi = 25; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 223; p = p.offset(prime_ * 4 + 0);
+                                   *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                    break 'label26
                                   }
                                   if p >= end { wi = 26; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 191; p = p.offset(prime_ * 8 + 1);
+                                  *p &= 191; p = (p as usize).saturating_add(prime * 8 + 1) as *mut u8;
                                   break 'label27
                                  }
                                  if p >= end { wi = 27; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 254; p = p.offset(prime_ * 6 + 0);
+                                 *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                  break 'label28
                                 }
                                 if p >= end { wi = 28; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 253; p = p.offset(prime_ * 4 + 0);
+                                *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                 break 'label29
                                }
                                if p >= end { wi = 29; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 251; p = p.offset(prime_ * 6 + 0);
+                               *p &= 251; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                                break 'label30
                               }
                               if p >= end { wi = 30; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 239; p = p.offset(prime_ * 2 + 0);
+                              *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                               break 'label31
                              }
                              if p >= end { wi = 31; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 223; p = p.offset(prime_ * 4 + 0);
+                             *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                              break 'label32
                             }
                             if p >= end { wi = 32; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 191; p = p.offset(prime_ * 6 + 0);
+                            *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                             break 'label33
                            }
                            if p >= end { wi = 33; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 127; p = p.offset(prime_ * 2 + 1);
+                           *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label34
                           }
                           if p >= end { wi = 34; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 254; p = p.offset(prime_ * 6 + 0);
+                          *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                           break 'label35
                          }
                          if p >= end { wi = 35; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 253; p = p.offset(prime_ * 6 + 0);
+                         *p &= 253; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                          break 'label36
                         }
                         if p >= end { wi = 36; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 247; p = p.offset(prime_ * 4 + 0);
+                        *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                         break 'label37
                        }
                        if p >= end { wi = 37; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 239; p = p.offset(prime_ * 2 + 0);
+                       *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                        break 'label38
                       }
                       if p >= end { wi = 38; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 223; p = p.offset(prime_ * 4 + 0);
+                      *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                       break 'label39
                      }
                      if p >= end { wi = 39; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 191; p = p.offset(prime_ * 6 + 0);
+                     *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                      break 'label40
                     }
                     if p >= end { wi = 40; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 127; p = p.offset(prime_ * 2 + 1);
+                    *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label41
                    }
                    if p >= end { wi = 41; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 254; p = p.offset(prime_ * 6 + 0);
+                   *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                    break 'label42
                   }
                   if p >= end { wi = 42; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 253; p = p.offset(prime_ * 4 + 0);
+                  *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                   break 'label43
                  }
                  if p >= end { wi = 43; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 251; p = p.offset(prime_ * 2 + 0);
+                 *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                  break 'label44
                 }
                 if p >= end { wi = 44; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 247; p = p.offset(prime_ * 4 + 0);
+                *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                 break 'label45
                }
                if p >= end { wi = 45; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 239; p = p.offset(prime_ * 2 + 0);
+               *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                break 'label46
               }
               if p >= end { wi = 46; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 223; p = p.offset(prime_ * 10 + 0);
+              *p &= 223; p = (p as usize).saturating_add(prime * 10 + 0) as *mut u8;
               break 'label47
              }
              if p >= end { wi = 47; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 127; p = p.offset(prime_ * 2 + 1);
+             *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 0
             }
         }
@@ -1284,391 +1284,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 0) &&
-                                                                             p.offset(prime_ * 10 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 0) < end);
                                                                 *p.offset(prime_ * 10 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 0) &&
-                                                                             p.offset(prime_ * 12 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 0) < end);
                                                                 *p.offset(prime_ * 12 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 0) &&
-                                                                             p.offset(prime_ * 16 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 0) < end);
                                                                 *p.offset(prime_ * 16 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 0) &&
-                                                                             p.offset(prime_ * 18 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 0) < end);
                                                                 *p.offset(prime_ * 18 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 0) &&
-                                                                             p.offset(prime_ * 22 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 0) < end);
                                                                 *p.offset(prime_ * 22 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 0) &&
-                                                                             p.offset(prime_ * 28 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 0) < end);
                                                                 *p.offset(prime_ * 28 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 1) &&
-                                                                             p.offset(prime_ * 30 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 1) < end);
                                                                 *p.offset(prime_ * 30 + 1) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 1) &&
-                                                                             p.offset(prime_ * 36 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 1) < end);
                                                                 *p.offset(prime_ * 36 + 1) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 1) &&
-                                                                             p.offset(prime_ * 40 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 1) < end);
                                                                 *p.offset(prime_ * 40 + 1) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 1) &&
-                                                                             p.offset(prime_ * 42 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 1) < end);
                                                                 *p.offset(prime_ * 42 + 1) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 1) &&
-                                                                             p.offset(prime_ * 46 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 1) < end);
                                                                 *p.offset(prime_ * 46 + 1) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 1) &&
-                                                                             p.offset(prime_ * 52 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 1) < end);
                                                                 *p.offset(prime_ * 52 + 1) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 1) &&
-                                                                             p.offset(prime_ * 58 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 1) < end);
                                                                 *p.offset(prime_ * 58 + 1) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 2) &&
-                                                                             p.offset(prime_ * 60 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 2) < end);
                                                                 *p.offset(prime_ * 60 + 2) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 2) &&
-                                                                             p.offset(prime_ * 66 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 2) < end);
                                                                 *p.offset(prime_ * 66 + 2) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 2) &&
-                                                                             p.offset(prime_ * 70 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 2) < end);
                                                                 *p.offset(prime_ * 70 + 2) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 2) &&
-                                                                             p.offset(prime_ * 72 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 2) < end);
                                                                 *p.offset(prime_ * 72 + 2) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 2) &&
-                                                                             p.offset(prime_ * 78 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 2) < end);
                                                                 *p.offset(prime_ * 78 + 2) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 2) &&
-                                                                             p.offset(prime_ * 82 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 2) < end);
                                                                 *p.offset(prime_ * 82 + 2) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 2) &&
-                                                                             p.offset(prime_ * 88 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 2) < end);
                                                                 *p.offset(prime_ * 88 + 2) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 3) &&
-                                                                             p.offset(prime_ * 96 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 3) < end);
                                                                 *p.offset(prime_ * 96 + 3) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 3) &&
-                                                                             p.offset(prime_ * 100 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 3) < end);
                                                                 *p.offset(prime_ * 100 + 3) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 3) &&
-                                                                             p.offset(prime_ * 102 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 3) < end);
                                                                 *p.offset(prime_ * 102 + 3) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 3) &&
-                                                                             p.offset(prime_ * 106 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 3) < end);
                                                                 *p.offset(prime_ * 106 + 3) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 3) &&
-                                                                             p.offset(prime_ * 108 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 3) < end);
                                                                 *p.offset(prime_ * 108 + 3) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 3) &&
-                                                                             p.offset(prime_ * 112 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 3) < end);
                                                                 *p.offset(prime_ * 112 + 3) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 4) &&
-                                                                             p.offset(prime_ * 120 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 4) < end);
                                                                 *p.offset(prime_ * 120 + 4) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 4) &&
-                                                                             p.offset(prime_ * 126 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 4) < end);
                                                                 *p.offset(prime_ * 126 + 4) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 4) &&
-                                                                             p.offset(prime_ * 130 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 4) < end);
                                                                 *p.offset(prime_ * 130 + 4) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 4) &&
-                                                                             p.offset(prime_ * 136 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 4) < end);
                                                                 *p.offset(prime_ * 136 + 4) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 4) &&
-                                                                             p.offset(prime_ * 138 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 4) < end);
                                                                 *p.offset(prime_ * 138 + 4) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 4) &&
-                                                                             p.offset(prime_ * 142 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 4) < end);
                                                                 *p.offset(prime_ * 142 + 4) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 4) &&
-                                                                             p.offset(prime_ * 148 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 4) < end);
                                                                 *p.offset(prime_ * 148 + 4) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 5) &&
-                                                                             p.offset(prime_ * 150 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 5) < end);
                                                                 *p.offset(prime_ * 150 + 5) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 5) &&
-                                                                             p.offset(prime_ * 156 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 5) < end);
                                                                 *p.offset(prime_ * 156 + 5) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 5) &&
-                                                                             p.offset(prime_ * 162 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 5) < end);
                                                                 *p.offset(prime_ * 162 + 5) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 5) &&
-                                                                             p.offset(prime_ * 166 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 5) < end);
                                                                 *p.offset(prime_ * 166 + 5) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 5) &&
-                                                                             p.offset(prime_ * 168 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 5) < end);
                                                                 *p.offset(prime_ * 168 + 5) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 5) &&
-                                                                             p.offset(prime_ * 172 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 5) < end);
                                                                 *p.offset(prime_ * 172 + 5) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 5) &&
-                                                                             p.offset(prime_ * 178 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 5) < end);
                                                                 *p.offset(prime_ * 178 + 5) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 6) &&
-                                                                             p.offset(prime_ * 180 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 6) < end);
                                                                 *p.offset(prime_ * 180 + 6) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 6) &&
-                                                                             p.offset(prime_ * 186 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 6) < end);
                                                                 *p.offset(prime_ * 186 + 6) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 6) &&
-                                                                             p.offset(prime_ * 190 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 6) < end);
                                                                 *p.offset(prime_ * 190 + 6) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 6) &&
-                                                                             p.offset(prime_ * 192 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 6) < end);
                                                                 *p.offset(prime_ * 192 + 6) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 6) &&
-                                                                             p.offset(prime_ * 196 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 6) < end);
                                                                 *p.offset(prime_ * 196 + 6) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 6) &&
-                                                                             p.offset(prime_ * 198 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 6) < end);
                                                                 *p.offset(prime_ * 198 + 6) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 6) &&
-                                                                             p.offset(prime_ * 208 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 6) < end);
                                                                 *p.offset(prime_ * 208 + 6) &= 191;
 
-                                                                p = p.offset(prime_ * 210 + 11)
+                                                                p = (p as usize).saturating_add(prime * 210 + 11) as *mut u8;
                                                             }
                                                             if p >= end { wi = 48; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 253; p = p.offset(prime_ * 10 + 2);
+                                                            *p &= 253; p = (p as usize).saturating_add(prime * 10 + 2) as *mut u8;
                                                             break 'label49
                                                            }
                                                            if p >= end { wi = 49; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 239; p = p.offset(prime_ * 2 + 1);
+                                                           *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                            break 'label50
                                                           }
                                                           if p >= end { wi = 50; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 254; p = p.offset(prime_ * 4 + 0);
+                                                          *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                                           break 'label51
                                                          }
                                                          if p >= end { wi = 51; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 127; p = p.offset(prime_ * 2 + 1);
+                                                         *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                          break 'label52
                                                         }
                                                         if p >= end { wi = 52; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 247; p = p.offset(prime_ * 4 + 1);
+                                                        *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                                         break 'label53
                                                        }
                                                        if p >= end { wi = 53; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 251; p = p.offset(prime_ * 6 + 1);
+                                                       *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                                        break 'label54
                                                       }
                                                       if p >= end { wi = 54; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 191; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label55
                                                      }
                                                      if p >= end { wi = 55; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 253; p = p.offset(prime_ * 6 + 1);
+                                                     *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                                      break 'label56
                                                     }
                                                     if p >= end { wi = 56; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 223; p = p.offset(prime_ * 4 + 1);
+                                                    *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                                     break 'label57
                                                    }
                                                    if p >= end { wi = 57; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 239; p = p.offset(prime_ * 2 + 1);
+                                                   *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                    break 'label58
                                                   }
                                                   if p >= end { wi = 58; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 254; p = p.offset(prime_ * 4 + 0);
+                                                  *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                                   break 'label59
                                                  }
                                                  if p >= end { wi = 59; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 127; p = p.offset(prime_ * 6 + 2);
+                                                 *p &= 127; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                                  break 'label60
                                                 }
                                                 if p >= end { wi = 60; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 251; p = p.offset(prime_ * 6 + 1);
+                                                *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                                 break 'label61
                                                }
                                                if p >= end { wi = 61; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 191; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label62
                                               }
                                               if p >= end { wi = 62; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 253; p = p.offset(prime_ * 6 + 1);
+                                              *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                               break 'label63
                                              }
                                              if p >= end { wi = 63; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 223; p = p.offset(prime_ * 4 + 1);
+                                             *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                              break 'label64
                                             }
                                             if p >= end { wi = 64; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 239; p = p.offset(prime_ * 2 + 1);
+                                            *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                             break 'label65
                                            }
                                            if p >= end { wi = 65; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 254; p = p.offset(prime_ * 6 + 1);
+                                           *p &= 254; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                            break 'label66
                                           }
                                           if p >= end { wi = 66; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 247; p = p.offset(prime_ * 4 + 1);
+                                          *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                           break 'label67
                                          }
                                          if p >= end { wi = 67; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 251; p = p.offset(prime_ * 6 + 1);
+                                         *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                          break 'label68
                                         }
                                         if p >= end { wi = 68; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 191; p = p.offset(prime_ * 8 + 2);
+                                        *p &= 191; p = (p as usize).saturating_add(prime * 8 + 2) as *mut u8;
                                         break 'label69
                                        }
                                        if p >= end { wi = 69; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 223; p = p.offset(prime_ * 4 + 1);
+                                       *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                        break 'label70
                                       }
                                       if p >= end { wi = 70; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 239; p = p.offset(prime_ * 2 + 1);
+                                      *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                       break 'label71
                                      }
                                      if p >= end { wi = 71; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 254; p = p.offset(prime_ * 4 + 0);
+                                     *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                                      break 'label72
                                     }
                                     if p >= end { wi = 72; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 127; p = p.offset(prime_ * 2 + 1);
+                                    *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                     break 'label73
                                    }
                                    if p >= end { wi = 73; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 247; p = p.offset(prime_ * 4 + 1);
+                                   *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                    break 'label74
                                   }
                                   if p >= end { wi = 74; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 251; p = p.offset(prime_ * 8 + 2);
+                                  *p &= 251; p = (p as usize).saturating_add(prime * 8 + 2) as *mut u8;
                                   break 'label75
                                  }
                                  if p >= end { wi = 75; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 253; p = p.offset(prime_ * 6 + 1);
+                                 *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                  break 'label76
                                 }
                                 if p >= end { wi = 76; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 223; p = p.offset(prime_ * 4 + 1);
+                                *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                 break 'label77
                                }
                                if p >= end { wi = 77; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 239; p = p.offset(prime_ * 6 + 1);
+                               *p &= 239; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                                break 'label78
                               }
                               if p >= end { wi = 78; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 127; p = p.offset(prime_ * 2 + 1);
+                              *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                               break 'label79
                              }
                              if p >= end { wi = 79; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 247; p = p.offset(prime_ * 4 + 1);
+                             *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                              break 'label80
                             }
                             if p >= end { wi = 80; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 251; p = p.offset(prime_ * 6 + 1);
+                            *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                             break 'label81
                            }
                            if p >= end { wi = 81; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 191; p = p.offset(prime_ * 2 + 1);
+                           *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label82
                           }
                           if p >= end { wi = 82; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 253; p = p.offset(prime_ * 6 + 1);
+                          *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                           break 'label83
                          }
                          if p >= end { wi = 83; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 223; p = p.offset(prime_ * 6 + 2);
+                         *p &= 223; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                          break 'label84
                         }
                         if p >= end { wi = 84; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 254; p = p.offset(prime_ * 4 + 0);
+                        *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                         break 'label85
                        }
                        if p >= end { wi = 85; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 127; p = p.offset(prime_ * 2 + 1);
+                       *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                        break 'label86
                       }
                       if p >= end { wi = 86; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 247; p = p.offset(prime_ * 4 + 1);
+                      *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                       break 'label87
                      }
                      if p >= end { wi = 87; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 251; p = p.offset(prime_ * 6 + 1);
+                     *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                      break 'label88
                     }
                     if p >= end { wi = 88; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 191; p = p.offset(prime_ * 2 + 1);
+                    *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label89
                    }
                    if p >= end { wi = 89; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 253; p = p.offset(prime_ * 6 + 1);
+                   *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                    break 'label90
                   }
                   if p >= end { wi = 90; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 223; p = p.offset(prime_ * 4 + 1);
+                  *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                   break 'label91
                  }
                  if p >= end { wi = 91; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 239; p = p.offset(prime_ * 2 + 1);
+                 *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                  break 'label92
                 }
                 if p >= end { wi = 92; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 254; p = p.offset(prime_ * 4 + 0);
+                *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                 break 'label93
                }
                if p >= end { wi = 93; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 127; p = p.offset(prime_ * 2 + 1);
+               *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                break 'label94
               }
               if p >= end { wi = 94; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 247; p = p.offset(prime_ * 10 + 2);
+              *p &= 247; p = (p as usize).saturating_add(prime * 10 + 2) as *mut u8;
               break 'label95
              }
              if p >= end { wi = 95; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 191; p = p.offset(prime_ * 2 + 1);
+             *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 48
             }
         }
@@ -1775,391 +1775,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 0) &&
-                                                                             p.offset(prime_ * 10 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 0) < end);
                                                                 *p.offset(prime_ * 10 + 0) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 0) &&
-                                                                             p.offset(prime_ * 12 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 0) < end);
                                                                 *p.offset(prime_ * 12 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 0) &&
-                                                                             p.offset(prime_ * 16 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 0) < end);
                                                                 *p.offset(prime_ * 16 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 0) &&
-                                                                             p.offset(prime_ * 18 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 0) < end);
                                                                 *p.offset(prime_ * 18 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 1) &&
-                                                                             p.offset(prime_ * 22 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 1) < end);
                                                                 *p.offset(prime_ * 22 + 1) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 1) &&
-                                                                             p.offset(prime_ * 28 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 1) < end);
                                                                 *p.offset(prime_ * 28 + 1) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 1) &&
-                                                                             p.offset(prime_ * 30 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 1) < end);
                                                                 *p.offset(prime_ * 30 + 1) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 1) &&
-                                                                             p.offset(prime_ * 36 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 1) < end);
                                                                 *p.offset(prime_ * 36 + 1) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 2) &&
-                                                                             p.offset(prime_ * 40 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 2) < end);
                                                                 *p.offset(prime_ * 40 + 2) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 2) &&
-                                                                             p.offset(prime_ * 42 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 2) < end);
                                                                 *p.offset(prime_ * 42 + 2) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 2) &&
-                                                                             p.offset(prime_ * 46 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 2) < end);
                                                                 *p.offset(prime_ * 46 + 2) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 2) &&
-                                                                             p.offset(prime_ * 52 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 2) < end);
                                                                 *p.offset(prime_ * 52 + 2) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 3) &&
-                                                                             p.offset(prime_ * 58 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 3) < end);
                                                                 *p.offset(prime_ * 58 + 3) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 3) &&
-                                                                             p.offset(prime_ * 60 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 3) < end);
                                                                 *p.offset(prime_ * 60 + 3) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 3) &&
-                                                                             p.offset(prime_ * 66 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 3) < end);
                                                                 *p.offset(prime_ * 66 + 3) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 3) &&
-                                                                             p.offset(prime_ * 70 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 3) < end);
                                                                 *p.offset(prime_ * 70 + 3) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 3) &&
-                                                                             p.offset(prime_ * 72 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 3) < end);
                                                                 *p.offset(prime_ * 72 + 3) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 4) &&
-                                                                             p.offset(prime_ * 78 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 4) < end);
                                                                 *p.offset(prime_ * 78 + 4) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 4) &&
-                                                                             p.offset(prime_ * 82 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 4) < end);
                                                                 *p.offset(prime_ * 82 + 4) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 4) &&
-                                                                             p.offset(prime_ * 88 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 4) < end);
                                                                 *p.offset(prime_ * 88 + 4) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 5) &&
-                                                                             p.offset(prime_ * 96 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 5) < end);
                                                                 *p.offset(prime_ * 96 + 5) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 5) &&
-                                                                             p.offset(prime_ * 100 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 5) < end);
                                                                 *p.offset(prime_ * 100 + 5) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 5) &&
-                                                                             p.offset(prime_ * 102 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 5) < end);
                                                                 *p.offset(prime_ * 102 + 5) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 5) &&
-                                                                             p.offset(prime_ * 106 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 5) < end);
                                                                 *p.offset(prime_ * 106 + 5) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 5) &&
-                                                                             p.offset(prime_ * 108 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 5) < end);
                                                                 *p.offset(prime_ * 108 + 5) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 5) &&
-                                                                             p.offset(prime_ * 112 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 5) < end);
                                                                 *p.offset(prime_ * 112 + 5) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 6) &&
-                                                                             p.offset(prime_ * 120 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 6) < end);
                                                                 *p.offset(prime_ * 120 + 6) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 6) &&
-                                                                             p.offset(prime_ * 126 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 6) < end);
                                                                 *p.offset(prime_ * 126 + 6) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 6) &&
-                                                                             p.offset(prime_ * 130 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 6) < end);
                                                                 *p.offset(prime_ * 130 + 6) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 7) &&
-                                                                             p.offset(prime_ * 136 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 7) < end);
                                                                 *p.offset(prime_ * 136 + 7) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 7) &&
-                                                                             p.offset(prime_ * 138 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 7) < end);
                                                                 *p.offset(prime_ * 138 + 7) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 7) &&
-                                                                             p.offset(prime_ * 142 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 7) < end);
                                                                 *p.offset(prime_ * 142 + 7) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 7) &&
-                                                                             p.offset(prime_ * 148 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 7) < end);
                                                                 *p.offset(prime_ * 148 + 7) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 7) &&
-                                                                             p.offset(prime_ * 150 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 7) < end);
                                                                 *p.offset(prime_ * 150 + 7) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 8) &&
-                                                                             p.offset(prime_ * 156 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 8) < end);
                                                                 *p.offset(prime_ * 156 + 8) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 8) &&
-                                                                             p.offset(prime_ * 162 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 8) < end);
                                                                 *p.offset(prime_ * 162 + 8) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 8) &&
-                                                                             p.offset(prime_ * 166 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 8) < end);
                                                                 *p.offset(prime_ * 166 + 8) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 8) &&
-                                                                             p.offset(prime_ * 168 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 8) < end);
                                                                 *p.offset(prime_ * 168 + 8) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 9) &&
-                                                                             p.offset(prime_ * 172 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 9) < end);
                                                                 *p.offset(prime_ * 172 + 9) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 9) &&
-                                                                             p.offset(prime_ * 178 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 9) < end);
                                                                 *p.offset(prime_ * 178 + 9) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 9) &&
-                                                                             p.offset(prime_ * 180 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 9) < end);
                                                                 *p.offset(prime_ * 180 + 9) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 9) &&
-                                                                             p.offset(prime_ * 186 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 9) < end);
                                                                 *p.offset(prime_ * 186 + 9) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 10) &&
-                                                                             p.offset(prime_ * 190 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 10) < end);
                                                                 *p.offset(prime_ * 190 + 10) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 10) &&
-                                                                             p.offset(prime_ * 192 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 10) < end);
                                                                 *p.offset(prime_ * 192 + 10) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 10) &&
-                                                                             p.offset(prime_ * 196 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 10) < end);
                                                                 *p.offset(prime_ * 196 + 10) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 10) &&
-                                                                             p.offset(prime_ * 198 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 10) < end);
                                                                 *p.offset(prime_ * 198 + 10) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 10) &&
-                                                                             p.offset(prime_ * 208 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 10) < end);
                                                                 *p.offset(prime_ * 208 + 10) &= 223;
 
-                                                                p = p.offset(prime_ * 210 + 13)
+                                                                p = (p as usize).saturating_add(prime * 210 + 13) as *mut u8;
                                                             }
                                                             if p >= end { wi = 96; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 251; p = p.offset(prime_ * 10 + 4);
+                                                            *p &= 251; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
                                                             break 'label97
                                                            }
                                                            if p >= end { wi = 97; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 254; p = p.offset(prime_ * 2 + 0);
+                                                           *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                                            break 'label98
                                                           }
                                                           if p >= end { wi = 98; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 191; p = p.offset(prime_ * 4 + 2);
+                                                          *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                           break 'label99
                                                          }
                                                          if p >= end { wi = 99; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 253; p = p.offset(prime_ * 2 + 0);
+                                                         *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                                          break 'label100
                                                         }
                                                         if p >= end { wi = 100; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 127; p = p.offset(prime_ * 4 + 2);
+                                                        *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                         break 'label101
                                                        }
                                                        if p >= end { wi = 101; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 247; p = p.offset(prime_ * 6 + 2);
+                                                       *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                                        break 'label102
                                                       }
                                                       if p >= end { wi = 102; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 223; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label103
                                                      }
                                                      if p >= end { wi = 103; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 251; p = p.offset(prime_ * 6 + 2);
+                                                     *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                                      break 'label104
                                                     }
                                                     if p >= end { wi = 104; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 239; p = p.offset(prime_ * 4 + 2);
+                                                    *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                     break 'label105
                                                    }
                                                    if p >= end { wi = 105; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 254; p = p.offset(prime_ * 2 + 0);
+                                                   *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                                    break 'label106
                                                   }
                                                   if p >= end { wi = 106; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 191; p = p.offset(prime_ * 4 + 2);
+                                                  *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                   break 'label107
                                                  }
                                                  if p >= end { wi = 107; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 253; p = p.offset(prime_ * 6 + 2);
+                                                 *p &= 253; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                                  break 'label108
                                                 }
                                                 if p >= end { wi = 108; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 247; p = p.offset(prime_ * 6 + 2);
+                                                *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                                 break 'label109
                                                }
                                                if p >= end { wi = 109; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 223; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label110
                                               }
                                               if p >= end { wi = 110; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 251; p = p.offset(prime_ * 6 + 2);
+                                              *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                               break 'label111
                                              }
                                              if p >= end { wi = 111; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 239; p = p.offset(prime_ * 4 + 2);
+                                             *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                              break 'label112
                                             }
                                             if p >= end { wi = 112; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 254; p = p.offset(prime_ * 2 + 0);
+                                            *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                             break 'label113
                                            }
                                            if p >= end { wi = 113; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 191; p = p.offset(prime_ * 6 + 2);
+                                           *p &= 191; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                            break 'label114
                                           }
                                           if p >= end { wi = 114; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 127; p = p.offset(prime_ * 4 + 2);
+                                          *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                           break 'label115
                                          }
                                          if p >= end { wi = 115; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 247; p = p.offset(prime_ * 6 + 2);
+                                         *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                          break 'label116
                                         }
                                         if p >= end { wi = 116; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 223; p = p.offset(prime_ * 8 + 3);
+                                        *p &= 223; p = (p as usize).saturating_add(prime * 8 + 3) as *mut u8;
                                         break 'label117
                                        }
                                        if p >= end { wi = 117; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 239; p = p.offset(prime_ * 4 + 2);
+                                       *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                        break 'label118
                                       }
                                       if p >= end { wi = 118; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 254; p = p.offset(prime_ * 2 + 0);
+                                      *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                       break 'label119
                                      }
                                      if p >= end { wi = 119; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 191; p = p.offset(prime_ * 4 + 2);
+                                     *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                      break 'label120
                                     }
                                     if p >= end { wi = 120; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 253; p = p.offset(prime_ * 2 + 0);
+                                    *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                                     break 'label121
                                    }
                                    if p >= end { wi = 121; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 127; p = p.offset(prime_ * 4 + 2);
+                                   *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                    break 'label122
                                   }
                                   if p >= end { wi = 122; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 247; p = p.offset(prime_ * 8 + 3);
+                                  *p &= 247; p = (p as usize).saturating_add(prime * 8 + 3) as *mut u8;
                                   break 'label123
                                  }
                                  if p >= end { wi = 123; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 251; p = p.offset(prime_ * 6 + 2);
+                                 *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                  break 'label124
                                 }
                                 if p >= end { wi = 124; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 239; p = p.offset(prime_ * 4 + 2);
+                                *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                 break 'label125
                                }
                                if p >= end { wi = 125; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 254; p = p.offset(prime_ * 6 + 2);
+                               *p &= 254; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                break 'label126
                               }
                               if p >= end { wi = 126; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 253; p = p.offset(prime_ * 2 + 0);
+                              *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                               break 'label127
                              }
                              if p >= end { wi = 127; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 127; p = p.offset(prime_ * 4 + 2);
+                             *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                              break 'label128
                             }
                             if p >= end { wi = 128; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 247; p = p.offset(prime_ * 6 + 2);
+                            *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                             break 'label129
                            }
                            if p >= end { wi = 129; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 223; p = p.offset(prime_ * 2 + 1);
+                           *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label130
                           }
                           if p >= end { wi = 130; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 251; p = p.offset(prime_ * 6 + 2);
+                          *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                           break 'label131
                          }
                          if p >= end { wi = 131; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 239; p = p.offset(prime_ * 6 + 2);
+                         *p &= 239; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                          break 'label132
                         }
                         if p >= end { wi = 132; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 191; p = p.offset(prime_ * 4 + 2);
+                        *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                         break 'label133
                        }
                        if p >= end { wi = 133; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 253; p = p.offset(prime_ * 2 + 0);
+                       *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                        break 'label134
                       }
                       if p >= end { wi = 134; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 127; p = p.offset(prime_ * 4 + 2);
+                      *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                       break 'label135
                      }
                      if p >= end { wi = 135; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 247; p = p.offset(prime_ * 6 + 2);
+                     *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                      break 'label136
                     }
                     if p >= end { wi = 136; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 223; p = p.offset(prime_ * 2 + 1);
+                    *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label137
                    }
                    if p >= end { wi = 137; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 251; p = p.offset(prime_ * 6 + 2);
+                   *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                    break 'label138
                   }
                   if p >= end { wi = 138; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 239; p = p.offset(prime_ * 4 + 2);
+                  *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                   break 'label139
                  }
                  if p >= end { wi = 139; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 254; p = p.offset(prime_ * 2 + 0);
+                 *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                  break 'label140
                 }
                 if p >= end { wi = 140; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 191; p = p.offset(prime_ * 4 + 2);
+                *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                 break 'label141
                }
                if p >= end { wi = 141; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 253; p = p.offset(prime_ * 2 + 0);
+               *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                break 'label142
               }
               if p >= end { wi = 142; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 127; p = p.offset(prime_ * 10 + 4);
+              *p &= 127; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
               break 'label143
              }
              if p >= end { wi = 143; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 223; p = p.offset(prime_ * 2 + 1);
+             *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 96
             }
         }
@@ -2266,391 +2266,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 0) &&
-                                                                             p.offset(prime_ * 10 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 0) < end);
                                                                 *p.offset(prime_ * 10 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 0) &&
-                                                                             p.offset(prime_ * 12 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 0) < end);
                                                                 *p.offset(prime_ * 12 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 1) &&
-                                                                             p.offset(prime_ * 16 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 1) < end);
                                                                 *p.offset(prime_ * 16 + 1) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 1) &&
-                                                                             p.offset(prime_ * 18 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 1) < end);
                                                                 *p.offset(prime_ * 18 + 1) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 1) &&
-                                                                             p.offset(prime_ * 22 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 1) < end);
                                                                 *p.offset(prime_ * 22 + 1) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 1) &&
-                                                                             p.offset(prime_ * 28 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 1) < end);
                                                                 *p.offset(prime_ * 28 + 1) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 1) &&
-                                                                             p.offset(prime_ * 30 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 1) < end);
                                                                 *p.offset(prime_ * 30 + 1) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 2) &&
-                                                                             p.offset(prime_ * 36 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 2) < end);
                                                                 *p.offset(prime_ * 36 + 2) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 2) &&
-                                                                             p.offset(prime_ * 40 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 2) < end);
                                                                 *p.offset(prime_ * 40 + 2) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 2) &&
-                                                                             p.offset(prime_ * 42 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 2) < end);
                                                                 *p.offset(prime_ * 42 + 2) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 2) &&
-                                                                             p.offset(prime_ * 46 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 2) < end);
                                                                 *p.offset(prime_ * 46 + 2) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 3) &&
-                                                                             p.offset(prime_ * 52 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 3) < end);
                                                                 *p.offset(prime_ * 52 + 3) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 3) &&
-                                                                             p.offset(prime_ * 58 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 3) < end);
                                                                 *p.offset(prime_ * 58 + 3) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 3) &&
-                                                                             p.offset(prime_ * 60 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 3) < end);
                                                                 *p.offset(prime_ * 60 + 3) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 4) &&
-                                                                             p.offset(prime_ * 66 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 4) < end);
                                                                 *p.offset(prime_ * 66 + 4) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 4) &&
-                                                                             p.offset(prime_ * 70 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 4) < end);
                                                                 *p.offset(prime_ * 70 + 4) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 4) &&
-                                                                             p.offset(prime_ * 72 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 4) < end);
                                                                 *p.offset(prime_ * 72 + 4) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 4) &&
-                                                                             p.offset(prime_ * 78 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 4) < end);
                                                                 *p.offset(prime_ * 78 + 4) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 5) &&
-                                                                             p.offset(prime_ * 82 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 5) < end);
                                                                 *p.offset(prime_ * 82 + 5) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 5) &&
-                                                                             p.offset(prime_ * 88 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 5) < end);
                                                                 *p.offset(prime_ * 88 + 5) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 6) &&
-                                                                             p.offset(prime_ * 96 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 6) < end);
                                                                 *p.offset(prime_ * 96 + 6) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 6) &&
-                                                                             p.offset(prime_ * 100 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 6) < end);
                                                                 *p.offset(prime_ * 100 + 6) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 6) &&
-                                                                             p.offset(prime_ * 102 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 6) < end);
                                                                 *p.offset(prime_ * 102 + 6) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 6) &&
-                                                                             p.offset(prime_ * 106 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 6) < end);
                                                                 *p.offset(prime_ * 106 + 6) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 6) &&
-                                                                             p.offset(prime_ * 108 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 6) < end);
                                                                 *p.offset(prime_ * 108 + 6) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 6) &&
-                                                                             p.offset(prime_ * 112 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 6) < end);
                                                                 *p.offset(prime_ * 112 + 6) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 7) &&
-                                                                             p.offset(prime_ * 120 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 7) < end);
                                                                 *p.offset(prime_ * 120 + 7) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 7) &&
-                                                                             p.offset(prime_ * 126 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 7) < end);
                                                                 *p.offset(prime_ * 126 + 7) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 8) &&
-                                                                             p.offset(prime_ * 130 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 8) < end);
                                                                 *p.offset(prime_ * 130 + 8) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 8) &&
-                                                                             p.offset(prime_ * 136 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 8) < end);
                                                                 *p.offset(prime_ * 136 + 8) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 8) &&
-                                                                             p.offset(prime_ * 138 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 8) < end);
                                                                 *p.offset(prime_ * 138 + 8) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 8) &&
-                                                                             p.offset(prime_ * 142 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 8) < end);
                                                                 *p.offset(prime_ * 142 + 8) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 9) &&
-                                                                             p.offset(prime_ * 148 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 9) < end);
                                                                 *p.offset(prime_ * 148 + 9) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 9) &&
-                                                                             p.offset(prime_ * 150 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 9) < end);
                                                                 *p.offset(prime_ * 150 + 9) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 9) &&
-                                                                             p.offset(prime_ * 156 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 9) < end);
                                                                 *p.offset(prime_ * 156 + 9) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 10) &&
-                                                                             p.offset(prime_ * 162 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 10) < end);
                                                                 *p.offset(prime_ * 162 + 10) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 10) &&
-                                                                             p.offset(prime_ * 166 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 10) < end);
                                                                 *p.offset(prime_ * 166 + 10) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 10) &&
-                                                                             p.offset(prime_ * 168 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 10) < end);
                                                                 *p.offset(prime_ * 168 + 10) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 10) &&
-                                                                             p.offset(prime_ * 172 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 10) < end);
                                                                 *p.offset(prime_ * 172 + 10) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 11) &&
-                                                                             p.offset(prime_ * 178 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 11) < end);
                                                                 *p.offset(prime_ * 178 + 11) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 11) &&
-                                                                             p.offset(prime_ * 180 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 11) < end);
                                                                 *p.offset(prime_ * 180 + 11) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 11) &&
-                                                                             p.offset(prime_ * 186 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 11) < end);
                                                                 *p.offset(prime_ * 186 + 11) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 11) &&
-                                                                             p.offset(prime_ * 190 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 11) < end);
                                                                 *p.offset(prime_ * 190 + 11) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 11) &&
-                                                                             p.offset(prime_ * 192 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 11) < end);
                                                                 *p.offset(prime_ * 192 + 11) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 12) &&
-                                                                             p.offset(prime_ * 196 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 12) < end);
                                                                 *p.offset(prime_ * 196 + 12) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 12) &&
-                                                                             p.offset(prime_ * 198 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 12) < end);
                                                                 *p.offset(prime_ * 198 + 12) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 12) &&
-                                                                             p.offset(prime_ * 208 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 12) < end);
                                                                 *p.offset(prime_ * 208 + 12) &= 239;
 
-                                                                p = p.offset(prime_ * 210 + 17)
+                                                                p = (p as usize).saturating_add(prime * 210 + 17) as *mut u8;
                                                             }
                                                             if p >= end { wi = 144; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 247; p = p.offset(prime_ * 10 + 4);
+                                                            *p &= 247; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
                                                             break 'label145
                                                            }
                                                            if p >= end { wi = 145; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 191; p = p.offset(prime_ * 2 + 1);
+                                                           *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                            break 'label146
                                                           }
                                                           if p >= end { wi = 146; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 223; p = p.offset(prime_ * 4 + 2);
+                                                          *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                           break 'label147
                                                          }
                                                          if p >= end { wi = 147; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 251; p = p.offset(prime_ * 2 + 1);
+                                                         *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                          break 'label148
                                                         }
                                                         if p >= end { wi = 148; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 253; p = p.offset(prime_ * 4 + 1);
+                                                        *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                                         break 'label149
                                                        }
                                                        if p >= end { wi = 149; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 127; p = p.offset(prime_ * 6 + 3);
+                                                       *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                                        break 'label150
                                                       }
                                                       if p >= end { wi = 150; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 239; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label151
                                                      }
                                                      if p >= end { wi = 151; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 247; p = p.offset(prime_ * 6 + 3);
+                                                     *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                                      break 'label152
                                                     }
                                                     if p >= end { wi = 152; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 254; p = p.offset(prime_ * 4 + 1);
+                                                    *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                                     break 'label153
                                                    }
                                                    if p >= end { wi = 153; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 191; p = p.offset(prime_ * 2 + 1);
+                                                   *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                    break 'label154
                                                   }
                                                   if p >= end { wi = 154; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 223; p = p.offset(prime_ * 4 + 2);
+                                                  *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                   break 'label155
                                                  }
                                                  if p >= end { wi = 155; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 251; p = p.offset(prime_ * 6 + 2);
+                                                 *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                                                  break 'label156
                                                 }
                                                 if p >= end { wi = 156; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 127; p = p.offset(prime_ * 6 + 3);
+                                                *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                                 break 'label157
                                                }
                                                if p >= end { wi = 157; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 239; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label158
                                               }
                                               if p >= end { wi = 158; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 247; p = p.offset(prime_ * 6 + 3);
+                                              *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                               break 'label159
                                              }
                                              if p >= end { wi = 159; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 254; p = p.offset(prime_ * 4 + 1);
+                                             *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                              break 'label160
                                             }
                                             if p >= end { wi = 160; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 191; p = p.offset(prime_ * 2 + 1);
+                                            *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                             break 'label161
                                            }
                                            if p >= end { wi = 161; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 223; p = p.offset(prime_ * 6 + 3);
+                                           *p &= 223; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                            break 'label162
                                           }
                                           if p >= end { wi = 162; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 253; p = p.offset(prime_ * 4 + 1);
+                                          *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                           break 'label163
                                          }
                                          if p >= end { wi = 163; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 127; p = p.offset(prime_ * 6 + 3);
+                                         *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                          break 'label164
                                         }
                                         if p >= end { wi = 164; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 239; p = p.offset(prime_ * 8 + 4);
+                                        *p &= 239; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
                                         break 'label165
                                        }
                                        if p >= end { wi = 165; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 254; p = p.offset(prime_ * 4 + 1);
+                                       *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                        break 'label166
                                       }
                                       if p >= end { wi = 166; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 191; p = p.offset(prime_ * 2 + 1);
+                                      *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                       break 'label167
                                      }
                                      if p >= end { wi = 167; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 223; p = p.offset(prime_ * 4 + 2);
+                                     *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                      break 'label168
                                     }
                                     if p >= end { wi = 168; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 251; p = p.offset(prime_ * 2 + 1);
+                                    *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                     break 'label169
                                    }
                                    if p >= end { wi = 169; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 253; p = p.offset(prime_ * 4 + 1);
+                                   *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                    break 'label170
                                   }
                                   if p >= end { wi = 170; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 127; p = p.offset(prime_ * 8 + 4);
+                                  *p &= 127; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
                                   break 'label171
                                  }
                                  if p >= end { wi = 171; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 247; p = p.offset(prime_ * 6 + 3);
+                                 *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                  break 'label172
                                 }
                                 if p >= end { wi = 172; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 254; p = p.offset(prime_ * 4 + 1);
+                                *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                                 break 'label173
                                }
                                if p >= end { wi = 173; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 191; p = p.offset(prime_ * 6 + 3);
+                               *p &= 191; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                break 'label174
                               }
                               if p >= end { wi = 174; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 251; p = p.offset(prime_ * 2 + 1);
+                              *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                               break 'label175
                              }
                              if p >= end { wi = 175; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 253; p = p.offset(prime_ * 4 + 1);
+                             *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                              break 'label176
                             }
                             if p >= end { wi = 176; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 127; p = p.offset(prime_ * 6 + 3);
+                            *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                             break 'label177
                            }
                            if p >= end { wi = 177; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 239; p = p.offset(prime_ * 2 + 1);
+                           *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label178
                           }
                           if p >= end { wi = 178; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 247; p = p.offset(prime_ * 6 + 3);
+                          *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                           break 'label179
                          }
                          if p >= end { wi = 179; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 254; p = p.offset(prime_ * 6 + 2);
+                         *p &= 254; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                          break 'label180
                         }
                         if p >= end { wi = 180; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 223; p = p.offset(prime_ * 4 + 2);
+                        *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                         break 'label181
                        }
                        if p >= end { wi = 181; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 251; p = p.offset(prime_ * 2 + 1);
+                       *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                        break 'label182
                       }
                       if p >= end { wi = 182; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 253; p = p.offset(prime_ * 4 + 1);
+                      *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                       break 'label183
                      }
                      if p >= end { wi = 183; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 127; p = p.offset(prime_ * 6 + 3);
+                     *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                      break 'label184
                     }
                     if p >= end { wi = 184; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 239; p = p.offset(prime_ * 2 + 1);
+                    *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label185
                    }
                    if p >= end { wi = 185; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 247; p = p.offset(prime_ * 6 + 3);
+                   *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                    break 'label186
                   }
                   if p >= end { wi = 186; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 254; p = p.offset(prime_ * 4 + 1);
+                  *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                   break 'label187
                  }
                  if p >= end { wi = 187; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 191; p = p.offset(prime_ * 2 + 1);
+                 *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                  break 'label188
                 }
                 if p >= end { wi = 188; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 223; p = p.offset(prime_ * 4 + 2);
+                *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                 break 'label189
                }
                if p >= end { wi = 189; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 251; p = p.offset(prime_ * 2 + 1);
+               *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                break 'label190
               }
               if p >= end { wi = 190; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 253; p = p.offset(prime_ * 10 + 4);
+              *p &= 253; p = (p as usize).saturating_add(prime * 10 + 4) as *mut u8;
               break 'label191
              }
              if p >= end { wi = 191; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 239; p = p.offset(prime_ * 2 + 1);
+             *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 144
             }
         }
@@ -2757,391 +2757,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 0) &&
-                                                                             p.offset(prime_ * 10 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 0) < end);
                                                                 *p.offset(prime_ * 10 + 0) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 1) &&
-                                                                             p.offset(prime_ * 12 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 1) < end);
                                                                 *p.offset(prime_ * 12 + 1) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 1) &&
-                                                                             p.offset(prime_ * 16 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 1) < end);
                                                                 *p.offset(prime_ * 16 + 1) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 1) &&
-                                                                             p.offset(prime_ * 18 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 1) < end);
                                                                 *p.offset(prime_ * 18 + 1) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 1) &&
-                                                                             p.offset(prime_ * 22 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 1) < end);
                                                                 *p.offset(prime_ * 22 + 1) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 2) &&
-                                                                             p.offset(prime_ * 28 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 2) < end);
                                                                 *p.offset(prime_ * 28 + 2) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 2) &&
-                                                                             p.offset(prime_ * 30 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 2) < end);
                                                                 *p.offset(prime_ * 30 + 2) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 2) &&
-                                                                             p.offset(prime_ * 36 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 2) < end);
                                                                 *p.offset(prime_ * 36 + 2) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 3) &&
-                                                                             p.offset(prime_ * 40 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 3) < end);
                                                                 *p.offset(prime_ * 40 + 3) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 3) &&
-                                                                             p.offset(prime_ * 42 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 3) < end);
                                                                 *p.offset(prime_ * 42 + 3) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 3) &&
-                                                                             p.offset(prime_ * 46 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 3) < end);
                                                                 *p.offset(prime_ * 46 + 3) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 4) &&
-                                                                             p.offset(prime_ * 52 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 4) < end);
                                                                 *p.offset(prime_ * 52 + 4) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 4) &&
-                                                                             p.offset(prime_ * 58 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 4) < end);
                                                                 *p.offset(prime_ * 58 + 4) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 4) &&
-                                                                             p.offset(prime_ * 60 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 4) < end);
                                                                 *p.offset(prime_ * 60 + 4) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 5) &&
-                                                                             p.offset(prime_ * 66 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 5) < end);
                                                                 *p.offset(prime_ * 66 + 5) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 5) &&
-                                                                             p.offset(prime_ * 70 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 5) < end);
                                                                 *p.offset(prime_ * 70 + 5) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 5) &&
-                                                                             p.offset(prime_ * 72 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 5) < end);
                                                                 *p.offset(prime_ * 72 + 5) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 6) &&
-                                                                             p.offset(prime_ * 78 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 6) < end);
                                                                 *p.offset(prime_ * 78 + 6) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 6) &&
-                                                                             p.offset(prime_ * 82 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 6) < end);
                                                                 *p.offset(prime_ * 82 + 6) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 7) &&
-                                                                             p.offset(prime_ * 88 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 7) < end);
                                                                 *p.offset(prime_ * 88 + 7) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 7) &&
-                                                                             p.offset(prime_ * 96 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 7) < end);
                                                                 *p.offset(prime_ * 96 + 7) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 8) &&
-                                                                             p.offset(prime_ * 100 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 8) < end);
                                                                 *p.offset(prime_ * 100 + 8) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 8) &&
-                                                                             p.offset(prime_ * 102 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 8) < end);
                                                                 *p.offset(prime_ * 102 + 8) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 8) &&
-                                                                             p.offset(prime_ * 106 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 8) < end);
                                                                 *p.offset(prime_ * 106 + 8) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 8) &&
-                                                                             p.offset(prime_ * 108 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 8) < end);
                                                                 *p.offset(prime_ * 108 + 8) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 9) &&
-                                                                             p.offset(prime_ * 112 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 9) < end);
                                                                 *p.offset(prime_ * 112 + 9) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 9) &&
-                                                                             p.offset(prime_ * 120 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 9) < end);
                                                                 *p.offset(prime_ * 120 + 9) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 10) &&
-                                                                             p.offset(prime_ * 126 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 10) < end);
                                                                 *p.offset(prime_ * 126 + 10) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 10) &&
-                                                                             p.offset(prime_ * 130 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 10) < end);
                                                                 *p.offset(prime_ * 130 + 10) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 11) &&
-                                                                             p.offset(prime_ * 136 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 11) < end);
                                                                 *p.offset(prime_ * 136 + 11) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 11) &&
-                                                                             p.offset(prime_ * 138 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 11) < end);
                                                                 *p.offset(prime_ * 138 + 11) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 11) &&
-                                                                             p.offset(prime_ * 142 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 11) < end);
                                                                 *p.offset(prime_ * 142 + 11) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 12) &&
-                                                                             p.offset(prime_ * 148 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 12) < end);
                                                                 *p.offset(prime_ * 148 + 12) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 12) &&
-                                                                             p.offset(prime_ * 150 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 12) < end);
                                                                 *p.offset(prime_ * 150 + 12) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 12) &&
-                                                                             p.offset(prime_ * 156 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 12) < end);
                                                                 *p.offset(prime_ * 156 + 12) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 13) &&
-                                                                             p.offset(prime_ * 162 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 13) < end);
                                                                 *p.offset(prime_ * 162 + 13) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 13) &&
-                                                                             p.offset(prime_ * 166 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 13) < end);
                                                                 *p.offset(prime_ * 166 + 13) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 13) &&
-                                                                             p.offset(prime_ * 168 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 13) < end);
                                                                 *p.offset(prime_ * 168 + 13) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 14) &&
-                                                                             p.offset(prime_ * 172 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 14) < end);
                                                                 *p.offset(prime_ * 172 + 14) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 14) &&
-                                                                             p.offset(prime_ * 178 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 14) < end);
                                                                 *p.offset(prime_ * 178 + 14) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 14) &&
-                                                                             p.offset(prime_ * 180 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 14) < end);
                                                                 *p.offset(prime_ * 180 + 14) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 15) &&
-                                                                             p.offset(prime_ * 186 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 15) < end);
                                                                 *p.offset(prime_ * 186 + 15) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 15) &&
-                                                                             p.offset(prime_ * 190 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 15) < end);
                                                                 *p.offset(prime_ * 190 + 15) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 15) &&
-                                                                             p.offset(prime_ * 192 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 15) < end);
                                                                 *p.offset(prime_ * 192 + 15) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 15) &&
-                                                                             p.offset(prime_ * 196 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 15) < end);
                                                                 *p.offset(prime_ * 196 + 15) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 16) &&
-                                                                             p.offset(prime_ * 198 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 16) < end);
                                                                 *p.offset(prime_ * 198 + 16) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 16) &&
-                                                                             p.offset(prime_ * 208 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 16) < end);
                                                                 *p.offset(prime_ * 208 + 16) &= 247;
 
-                                                                p = p.offset(prime_ * 210 + 19)
+                                                                p = (p as usize).saturating_add(prime * 210 + 19) as *mut u8;
                                                             }
                                                             if p >= end { wi = 192; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 239; p = p.offset(prime_ * 10 + 6);
+                                                            *p &= 239; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
                                                             break 'label193
                                                            }
                                                            if p >= end { wi = 193; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 253; p = p.offset(prime_ * 2 + 1);
+                                                           *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                            break 'label194
                                                           }
                                                           if p >= end { wi = 194; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 251; p = p.offset(prime_ * 4 + 2);
+                                                          *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                           break 'label195
                                                          }
                                                          if p >= end { wi = 195; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 223; p = p.offset(prime_ * 2 + 1);
+                                                         *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                          break 'label196
                                                         }
                                                         if p >= end { wi = 196; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 191; p = p.offset(prime_ * 4 + 3);
+                                                        *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                                         break 'label197
                                                        }
                                                        if p >= end { wi = 197; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 254; p = p.offset(prime_ * 6 + 3);
+                                                       *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                                        break 'label198
                                                       }
                                                       if p >= end { wi = 198; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 247; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label199
                                                      }
                                                      if p >= end { wi = 199; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 239; p = p.offset(prime_ * 6 + 3);
+                                                     *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                                      break 'label200
                                                     }
                                                     if p >= end { wi = 200; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 127; p = p.offset(prime_ * 4 + 3);
+                                                    *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                                     break 'label201
                                                    }
                                                    if p >= end { wi = 201; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 253; p = p.offset(prime_ * 2 + 1);
+                                                   *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                    break 'label202
                                                   }
                                                   if p >= end { wi = 202; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 251; p = p.offset(prime_ * 4 + 2);
+                                                  *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                   break 'label203
                                                  }
                                                  if p >= end { wi = 203; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 223; p = p.offset(prime_ * 6 + 4);
+                                                 *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                                  break 'label204
                                                 }
                                                 if p >= end { wi = 204; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 254; p = p.offset(prime_ * 6 + 3);
+                                                *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                                 break 'label205
                                                }
                                                if p >= end { wi = 205; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 247; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label206
                                               }
                                               if p >= end { wi = 206; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 239; p = p.offset(prime_ * 6 + 3);
+                                              *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                               break 'label207
                                              }
                                              if p >= end { wi = 207; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 127; p = p.offset(prime_ * 4 + 3);
+                                             *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                              break 'label208
                                             }
                                             if p >= end { wi = 208; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 253; p = p.offset(prime_ * 2 + 1);
+                                            *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                             break 'label209
                                            }
                                            if p >= end { wi = 209; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 251; p = p.offset(prime_ * 6 + 3);
+                                           *p &= 251; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                            break 'label210
                                           }
                                           if p >= end { wi = 210; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 191; p = p.offset(prime_ * 4 + 3);
+                                          *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                           break 'label211
                                          }
                                          if p >= end { wi = 211; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 254; p = p.offset(prime_ * 6 + 3);
+                                         *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                          break 'label212
                                         }
                                         if p >= end { wi = 212; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 247; p = p.offset(prime_ * 8 + 4);
+                                        *p &= 247; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
                                         break 'label213
                                        }
                                        if p >= end { wi = 213; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 127; p = p.offset(prime_ * 4 + 3);
+                                       *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                        break 'label214
                                       }
                                       if p >= end { wi = 214; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 253; p = p.offset(prime_ * 2 + 1);
+                                      *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                       break 'label215
                                      }
                                      if p >= end { wi = 215; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 251; p = p.offset(prime_ * 4 + 2);
+                                     *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                      break 'label216
                                     }
                                     if p >= end { wi = 216; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 223; p = p.offset(prime_ * 2 + 1);
+                                    *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                     break 'label217
                                    }
                                    if p >= end { wi = 217; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 191; p = p.offset(prime_ * 4 + 3);
+                                   *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                    break 'label218
                                   }
                                   if p >= end { wi = 218; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 254; p = p.offset(prime_ * 8 + 4);
+                                  *p &= 254; p = (p as usize).saturating_add(prime * 8 + 4) as *mut u8;
                                   break 'label219
                                  }
                                  if p >= end { wi = 219; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 239; p = p.offset(prime_ * 6 + 3);
+                                 *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                  break 'label220
                                 }
                                 if p >= end { wi = 220; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 127; p = p.offset(prime_ * 4 + 3);
+                                *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                 break 'label221
                                }
                                if p >= end { wi = 221; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 253; p = p.offset(prime_ * 6 + 3);
+                               *p &= 253; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                                break 'label222
                               }
                               if p >= end { wi = 222; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 223; p = p.offset(prime_ * 2 + 1);
+                              *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                               break 'label223
                              }
                              if p >= end { wi = 223; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 191; p = p.offset(prime_ * 4 + 3);
+                             *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                              break 'label224
                             }
                             if p >= end { wi = 224; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 254; p = p.offset(prime_ * 6 + 3);
+                            *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                             break 'label225
                            }
                            if p >= end { wi = 225; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 247; p = p.offset(prime_ * 2 + 1);
+                           *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label226
                           }
                           if p >= end { wi = 226; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 239; p = p.offset(prime_ * 6 + 3);
+                          *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                           break 'label227
                          }
                          if p >= end { wi = 227; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 127; p = p.offset(prime_ * 6 + 4);
+                         *p &= 127; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                          break 'label228
                         }
                         if p >= end { wi = 228; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 251; p = p.offset(prime_ * 4 + 2);
+                        *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                         break 'label229
                        }
                        if p >= end { wi = 229; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 223; p = p.offset(prime_ * 2 + 1);
+                       *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                        break 'label230
                       }
                       if p >= end { wi = 230; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 191; p = p.offset(prime_ * 4 + 3);
+                      *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                       break 'label231
                      }
                      if p >= end { wi = 231; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 254; p = p.offset(prime_ * 6 + 3);
+                     *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                      break 'label232
                     }
                     if p >= end { wi = 232; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 247; p = p.offset(prime_ * 2 + 1);
+                    *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label233
                    }
                    if p >= end { wi = 233; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 239; p = p.offset(prime_ * 6 + 3);
+                   *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                    break 'label234
                   }
                   if p >= end { wi = 234; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 127; p = p.offset(prime_ * 4 + 3);
+                  *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                   break 'label235
                  }
                  if p >= end { wi = 235; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 253; p = p.offset(prime_ * 2 + 1);
+                 *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                  break 'label236
                 }
                 if p >= end { wi = 236; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 251; p = p.offset(prime_ * 4 + 2);
+                *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                 break 'label237
                }
                if p >= end { wi = 237; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 223; p = p.offset(prime_ * 2 + 1);
+               *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                break 'label238
               }
               if p >= end { wi = 238; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 191; p = p.offset(prime_ * 10 + 6);
+              *p &= 191; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
               break 'label239
              }
              if p >= end { wi = 239; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 247; p = p.offset(prime_ * 2 + 1);
+             *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 192
             }
         }
@@ -3248,391 +3248,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 0) &&
-                                                                             p.offset(prime_ * 10 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 0) < end);
                                                                 *p.offset(prime_ * 10 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 1) &&
-                                                                             p.offset(prime_ * 12 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 1) < end);
                                                                 *p.offset(prime_ * 12 + 1) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 1) &&
-                                                                             p.offset(prime_ * 16 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 1) < end);
                                                                 *p.offset(prime_ * 16 + 1) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 1) &&
-                                                                             p.offset(prime_ * 18 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 1) < end);
                                                                 *p.offset(prime_ * 18 + 1) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 2) &&
-                                                                             p.offset(prime_ * 22 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 2) < end);
                                                                 *p.offset(prime_ * 22 + 2) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 2) &&
-                                                                             p.offset(prime_ * 28 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 2) < end);
                                                                 *p.offset(prime_ * 28 + 2) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 2) &&
-                                                                             p.offset(prime_ * 30 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 2) < end);
                                                                 *p.offset(prime_ * 30 + 2) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 3) &&
-                                                                             p.offset(prime_ * 36 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 3) < end);
                                                                 *p.offset(prime_ * 36 + 3) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 3) &&
-                                                                             p.offset(prime_ * 40 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 3) < end);
                                                                 *p.offset(prime_ * 40 + 3) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 3) &&
-                                                                             p.offset(prime_ * 42 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 3) < end);
                                                                 *p.offset(prime_ * 42 + 3) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 4) &&
-                                                                             p.offset(prime_ * 46 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 4) < end);
                                                                 *p.offset(prime_ * 46 + 4) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 4) &&
-                                                                             p.offset(prime_ * 52 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 4) < end);
                                                                 *p.offset(prime_ * 52 + 4) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 5) &&
-                                                                             p.offset(prime_ * 58 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 5) < end);
                                                                 *p.offset(prime_ * 58 + 5) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 5) &&
-                                                                             p.offset(prime_ * 60 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 5) < end);
                                                                 *p.offset(prime_ * 60 + 5) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 6) &&
-                                                                             p.offset(prime_ * 66 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 6) < end);
                                                                 *p.offset(prime_ * 66 + 6) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 6) &&
-                                                                             p.offset(prime_ * 70 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 6) < end);
                                                                 *p.offset(prime_ * 70 + 6) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 6) &&
-                                                                             p.offset(prime_ * 72 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 6) < end);
                                                                 *p.offset(prime_ * 72 + 6) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 7) &&
-                                                                             p.offset(prime_ * 78 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 7) < end);
                                                                 *p.offset(prime_ * 78 + 7) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 7) &&
-                                                                             p.offset(prime_ * 82 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 7) < end);
                                                                 *p.offset(prime_ * 82 + 7) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 8) &&
-                                                                             p.offset(prime_ * 88 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 8) < end);
                                                                 *p.offset(prime_ * 88 + 8) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 8) &&
-                                                                             p.offset(prime_ * 96 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 8) < end);
                                                                 *p.offset(prime_ * 96 + 8) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 9) &&
-                                                                             p.offset(prime_ * 100 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 9) < end);
                                                                 *p.offset(prime_ * 100 + 9) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 9) &&
-                                                                             p.offset(prime_ * 102 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 9) < end);
                                                                 *p.offset(prime_ * 102 + 9) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 9) &&
-                                                                             p.offset(prime_ * 106 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 9) < end);
                                                                 *p.offset(prime_ * 106 + 9) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 9) &&
-                                                                             p.offset(prime_ * 108 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 9) < end);
                                                                 *p.offset(prime_ * 108 + 9) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 10) &&
-                                                                             p.offset(prime_ * 112 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 10) < end);
                                                                 *p.offset(prime_ * 112 + 10) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 10) &&
-                                                                             p.offset(prime_ * 120 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 10) < end);
                                                                 *p.offset(prime_ * 120 + 10) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 11) &&
-                                                                             p.offset(prime_ * 126 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 11) < end);
                                                                 *p.offset(prime_ * 126 + 11) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 11) &&
-                                                                             p.offset(prime_ * 130 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 11) < end);
                                                                 *p.offset(prime_ * 130 + 11) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 12) &&
-                                                                             p.offset(prime_ * 136 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 12) < end);
                                                                 *p.offset(prime_ * 136 + 12) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 12) &&
-                                                                             p.offset(prime_ * 138 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 12) < end);
                                                                 *p.offset(prime_ * 138 + 12) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 12) &&
-                                                                             p.offset(prime_ * 142 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 12) < end);
                                                                 *p.offset(prime_ * 142 + 12) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 13) &&
-                                                                             p.offset(prime_ * 148 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 13) < end);
                                                                 *p.offset(prime_ * 148 + 13) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 13) &&
-                                                                             p.offset(prime_ * 150 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 13) < end);
                                                                 *p.offset(prime_ * 150 + 13) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 14) &&
-                                                                             p.offset(prime_ * 156 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 14) < end);
                                                                 *p.offset(prime_ * 156 + 14) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 14) &&
-                                                                             p.offset(prime_ * 162 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 14) < end);
                                                                 *p.offset(prime_ * 162 + 14) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 15) &&
-                                                                             p.offset(prime_ * 166 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 15) < end);
                                                                 *p.offset(prime_ * 166 + 15) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 15) &&
-                                                                             p.offset(prime_ * 168 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 15) < end);
                                                                 *p.offset(prime_ * 168 + 15) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 15) &&
-                                                                             p.offset(prime_ * 172 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 15) < end);
                                                                 *p.offset(prime_ * 172 + 15) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 16) &&
-                                                                             p.offset(prime_ * 178 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 16) < end);
                                                                 *p.offset(prime_ * 178 + 16) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 16) &&
-                                                                             p.offset(prime_ * 180 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 16) < end);
                                                                 *p.offset(prime_ * 180 + 16) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 16) &&
-                                                                             p.offset(prime_ * 186 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 16) < end);
                                                                 *p.offset(prime_ * 186 + 16) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 17) &&
-                                                                             p.offset(prime_ * 190 + 17) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 17) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 17) < end);
                                                                 *p.offset(prime_ * 190 + 17) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 17) &&
-                                                                             p.offset(prime_ * 192 + 17) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 17) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 17) < end);
                                                                 *p.offset(prime_ * 192 + 17) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 17) &&
-                                                                             p.offset(prime_ * 196 + 17) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 17) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 17) < end);
                                                                 *p.offset(prime_ * 196 + 17) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 18) &&
-                                                                             p.offset(prime_ * 198 + 18) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 18) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 18) < end);
                                                                 *p.offset(prime_ * 198 + 18) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 18) &&
-                                                                             p.offset(prime_ * 208 + 18) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 18) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 18) < end);
                                                                 *p.offset(prime_ * 208 + 18) &= 251;
 
-                                                                p = p.offset(prime_ * 210 + 23)
+                                                                p = (p as usize).saturating_add(prime * 210 + 23) as *mut u8;
                                                             }
                                                             if p >= end { wi = 240; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 223; p = p.offset(prime_ * 10 + 6);
+                                                            *p &= 223; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
                                                             break 'label241
                                                            }
                                                            if p >= end { wi = 241; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 127; p = p.offset(prime_ * 2 + 2);
+                                                           *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                                            break 'label242
                                                           }
                                                           if p >= end { wi = 242; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 253; p = p.offset(prime_ * 4 + 2);
+                                                          *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                           break 'label243
                                                          }
                                                          if p >= end { wi = 243; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 191; p = p.offset(prime_ * 2 + 2);
+                                                         *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                                          break 'label244
                                                         }
                                                         if p >= end { wi = 244; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 254; p = p.offset(prime_ * 4 + 2);
+                                                        *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                         break 'label245
                                                        }
                                                        if p >= end { wi = 245; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 239; p = p.offset(prime_ * 6 + 4);
+                                                       *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                                        break 'label246
                                                       }
                                                       if p >= end { wi = 246; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 251; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label247
                                                      }
                                                      if p >= end { wi = 247; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 223; p = p.offset(prime_ * 6 + 4);
+                                                     *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                                      break 'label248
                                                     }
                                                     if p >= end { wi = 248; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 247; p = p.offset(prime_ * 4 + 2);
+                                                    *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                     break 'label249
                                                    }
                                                    if p >= end { wi = 249; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 127; p = p.offset(prime_ * 2 + 2);
+                                                   *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                                    break 'label250
                                                   }
                                                   if p >= end { wi = 250; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 253; p = p.offset(prime_ * 4 + 2);
+                                                  *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                                   break 'label251
                                                  }
                                                  if p >= end { wi = 251; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 191; p = p.offset(prime_ * 6 + 4);
+                                                 *p &= 191; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                                  break 'label252
                                                 }
                                                 if p >= end { wi = 252; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 239; p = p.offset(prime_ * 6 + 4);
+                                                *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                                 break 'label253
                                                }
                                                if p >= end { wi = 253; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 251; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label254
                                               }
                                               if p >= end { wi = 254; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 223; p = p.offset(prime_ * 6 + 4);
+                                              *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                               break 'label255
                                              }
                                              if p >= end { wi = 255; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 247; p = p.offset(prime_ * 4 + 2);
+                                             *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                              break 'label256
                                             }
                                             if p >= end { wi = 256; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 127; p = p.offset(prime_ * 2 + 2);
+                                            *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                             break 'label257
                                            }
                                            if p >= end { wi = 257; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 253; p = p.offset(prime_ * 6 + 4);
+                                           *p &= 253; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                            break 'label258
                                           }
                                           if p >= end { wi = 258; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 254; p = p.offset(prime_ * 4 + 2);
+                                          *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                           break 'label259
                                          }
                                          if p >= end { wi = 259; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 239; p = p.offset(prime_ * 6 + 4);
+                                         *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                          break 'label260
                                         }
                                         if p >= end { wi = 260; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 251; p = p.offset(prime_ * 8 + 5);
+                                        *p &= 251; p = (p as usize).saturating_add(prime * 8 + 5) as *mut u8;
                                         break 'label261
                                        }
                                        if p >= end { wi = 261; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 247; p = p.offset(prime_ * 4 + 2);
+                                       *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                        break 'label262
                                       }
                                       if p >= end { wi = 262; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 127; p = p.offset(prime_ * 2 + 2);
+                                      *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                       break 'label263
                                      }
                                      if p >= end { wi = 263; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 253; p = p.offset(prime_ * 4 + 2);
+                                     *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                      break 'label264
                                     }
                                     if p >= end { wi = 264; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 191; p = p.offset(prime_ * 2 + 2);
+                                    *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                     break 'label265
                                    }
                                    if p >= end { wi = 265; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 254; p = p.offset(prime_ * 4 + 2);
+                                   *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                    break 'label266
                                   }
                                   if p >= end { wi = 266; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 239; p = p.offset(prime_ * 8 + 5);
+                                  *p &= 239; p = (p as usize).saturating_add(prime * 8 + 5) as *mut u8;
                                   break 'label267
                                  }
                                  if p >= end { wi = 267; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 223; p = p.offset(prime_ * 6 + 4);
+                                 *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                  break 'label268
                                 }
                                 if p >= end { wi = 268; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 247; p = p.offset(prime_ * 4 + 2);
+                                *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                                 break 'label269
                                }
                                if p >= end { wi = 269; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 127; p = p.offset(prime_ * 6 + 4);
+                               *p &= 127; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                break 'label270
                               }
                               if p >= end { wi = 270; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 191; p = p.offset(prime_ * 2 + 2);
+                              *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                               break 'label271
                              }
                              if p >= end { wi = 271; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 254; p = p.offset(prime_ * 4 + 2);
+                             *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                              break 'label272
                             }
                             if p >= end { wi = 272; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 239; p = p.offset(prime_ * 6 + 4);
+                            *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                             break 'label273
                            }
                            if p >= end { wi = 273; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 251; p = p.offset(prime_ * 2 + 1);
+                           *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label274
                           }
                           if p >= end { wi = 274; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 223; p = p.offset(prime_ * 6 + 4);
+                          *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                           break 'label275
                          }
                          if p >= end { wi = 275; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 247; p = p.offset(prime_ * 6 + 4);
+                         *p &= 247; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                          break 'label276
                         }
                         if p >= end { wi = 276; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 253; p = p.offset(prime_ * 4 + 2);
+                        *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                         break 'label277
                        }
                        if p >= end { wi = 277; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 191; p = p.offset(prime_ * 2 + 2);
+                       *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                        break 'label278
                       }
                       if p >= end { wi = 278; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 254; p = p.offset(prime_ * 4 + 2);
+                      *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                       break 'label279
                      }
                      if p >= end { wi = 279; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 239; p = p.offset(prime_ * 6 + 4);
+                     *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                      break 'label280
                     }
                     if p >= end { wi = 280; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 251; p = p.offset(prime_ * 2 + 1);
+                    *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label281
                    }
                    if p >= end { wi = 281; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 223; p = p.offset(prime_ * 6 + 4);
+                   *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                    break 'label282
                   }
                   if p >= end { wi = 282; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 247; p = p.offset(prime_ * 4 + 2);
+                  *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                   break 'label283
                  }
                  if p >= end { wi = 283; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 127; p = p.offset(prime_ * 2 + 2);
+                 *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                  break 'label284
                 }
                 if p >= end { wi = 284; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 253; p = p.offset(prime_ * 4 + 2);
+                *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                 break 'label285
                }
                if p >= end { wi = 285; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 191; p = p.offset(prime_ * 2 + 2);
+               *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                break 'label286
               }
               if p >= end { wi = 286; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 254; p = p.offset(prime_ * 10 + 6);
+              *p &= 254; p = (p as usize).saturating_add(prime * 10 + 6) as *mut u8;
               break 'label287
              }
              if p >= end { wi = 287; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 251; p = p.offset(prime_ * 2 + 1);
+             *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 240
             }
         }
@@ -3739,391 +3739,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 1) &&
-                                                                             p.offset(prime_ * 10 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 1) < end);
                                                                 *p.offset(prime_ * 10 + 1) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 1) &&
-                                                                             p.offset(prime_ * 12 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 1) < end);
                                                                 *p.offset(prime_ * 12 + 1) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 1) &&
-                                                                             p.offset(prime_ * 16 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 1) < end);
                                                                 *p.offset(prime_ * 16 + 1) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 2) &&
-                                                                             p.offset(prime_ * 18 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 2) < end);
                                                                 *p.offset(prime_ * 18 + 2) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 2) &&
-                                                                             p.offset(prime_ * 22 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 2) < end);
                                                                 *p.offset(prime_ * 22 + 2) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 3) &&
-                                                                             p.offset(prime_ * 28 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 3) < end);
                                                                 *p.offset(prime_ * 28 + 3) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 3) &&
-                                                                             p.offset(prime_ * 30 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 3) < end);
                                                                 *p.offset(prime_ * 30 + 3) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 4) &&
-                                                                             p.offset(prime_ * 36 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 4) < end);
                                                                 *p.offset(prime_ * 36 + 4) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 4) &&
-                                                                             p.offset(prime_ * 40 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 4) < end);
                                                                 *p.offset(prime_ * 40 + 4) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 4) &&
-                                                                             p.offset(prime_ * 42 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 4) < end);
                                                                 *p.offset(prime_ * 42 + 4) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 5) &&
-                                                                             p.offset(prime_ * 46 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 5) < end);
                                                                 *p.offset(prime_ * 46 + 5) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 5) &&
-                                                                             p.offset(prime_ * 52 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 5) < end);
                                                                 *p.offset(prime_ * 52 + 5) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 6) &&
-                                                                             p.offset(prime_ * 58 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 6) < end);
                                                                 *p.offset(prime_ * 58 + 6) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 6) &&
-                                                                             p.offset(prime_ * 60 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 6) < end);
                                                                 *p.offset(prime_ * 60 + 6) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 7) &&
-                                                                             p.offset(prime_ * 66 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 7) < end);
                                                                 *p.offset(prime_ * 66 + 7) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 7) &&
-                                                                             p.offset(prime_ * 70 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 7) < end);
                                                                 *p.offset(prime_ * 70 + 7) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 7) &&
-                                                                             p.offset(prime_ * 72 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 7) < end);
                                                                 *p.offset(prime_ * 72 + 7) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 8) &&
-                                                                             p.offset(prime_ * 78 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 8) < end);
                                                                 *p.offset(prime_ * 78 + 8) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 9) &&
-                                                                             p.offset(prime_ * 82 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 9) < end);
                                                                 *p.offset(prime_ * 82 + 9) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 9) &&
-                                                                             p.offset(prime_ * 88 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 9) < end);
                                                                 *p.offset(prime_ * 88 + 9) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 10) &&
-                                                                             p.offset(prime_ * 96 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 10) < end);
                                                                 *p.offset(prime_ * 96 + 10) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 11) &&
-                                                                             p.offset(prime_ * 100 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 11) < end);
                                                                 *p.offset(prime_ * 100 + 11) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 11) &&
-                                                                             p.offset(prime_ * 102 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 11) < end);
                                                                 *p.offset(prime_ * 102 + 11) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 11) &&
-                                                                             p.offset(prime_ * 106 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 11) < end);
                                                                 *p.offset(prime_ * 106 + 11) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 11) &&
-                                                                             p.offset(prime_ * 108 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 11) < end);
                                                                 *p.offset(prime_ * 108 + 11) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 12) &&
-                                                                             p.offset(prime_ * 112 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 12) < end);
                                                                 *p.offset(prime_ * 112 + 12) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 13) &&
-                                                                             p.offset(prime_ * 120 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 13) < end);
                                                                 *p.offset(prime_ * 120 + 13) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 13) &&
-                                                                             p.offset(prime_ * 126 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 13) < end);
                                                                 *p.offset(prime_ * 126 + 13) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 14) &&
-                                                                             p.offset(prime_ * 130 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 14) < end);
                                                                 *p.offset(prime_ * 130 + 14) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 15) &&
-                                                                             p.offset(prime_ * 136 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 15) < end);
                                                                 *p.offset(prime_ * 136 + 15) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 15) &&
-                                                                             p.offset(prime_ * 138 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 15) < end);
                                                                 *p.offset(prime_ * 138 + 15) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 15) &&
-                                                                             p.offset(prime_ * 142 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 15) < end);
                                                                 *p.offset(prime_ * 142 + 15) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 16) &&
-                                                                             p.offset(prime_ * 148 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 16) < end);
                                                                 *p.offset(prime_ * 148 + 16) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 16) &&
-                                                                             p.offset(prime_ * 150 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 16) < end);
                                                                 *p.offset(prime_ * 150 + 16) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 17) &&
-                                                                             p.offset(prime_ * 156 + 17) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 17) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 17) < end);
                                                                 *p.offset(prime_ * 156 + 17) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 17) &&
-                                                                             p.offset(prime_ * 162 + 17) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 17) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 17) < end);
                                                                 *p.offset(prime_ * 162 + 17) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 18) &&
-                                                                             p.offset(prime_ * 166 + 18) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 18) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 18) < end);
                                                                 *p.offset(prime_ * 166 + 18) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 18) &&
-                                                                             p.offset(prime_ * 168 + 18) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 18) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 18) < end);
                                                                 *p.offset(prime_ * 168 + 18) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 18) &&
-                                                                             p.offset(prime_ * 172 + 18) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 18) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 18) < end);
                                                                 *p.offset(prime_ * 172 + 18) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 19) &&
-                                                                             p.offset(prime_ * 178 + 19) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 19) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 19) < end);
                                                                 *p.offset(prime_ * 178 + 19) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 19) &&
-                                                                             p.offset(prime_ * 180 + 19) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 19) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 19) < end);
                                                                 *p.offset(prime_ * 180 + 19) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 20) &&
-                                                                             p.offset(prime_ * 186 + 20) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 20) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 20) < end);
                                                                 *p.offset(prime_ * 186 + 20) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 20) &&
-                                                                             p.offset(prime_ * 190 + 20) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 20) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 20) < end);
                                                                 *p.offset(prime_ * 190 + 20) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 21) &&
-                                                                             p.offset(prime_ * 192 + 21) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 21) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 21) < end);
                                                                 *p.offset(prime_ * 192 + 21) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 21) &&
-                                                                             p.offset(prime_ * 196 + 21) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 21) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 21) < end);
                                                                 *p.offset(prime_ * 196 + 21) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 21) &&
-                                                                             p.offset(prime_ * 198 + 21) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 21) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 21) < end);
                                                                 *p.offset(prime_ * 198 + 21) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 22) &&
-                                                                             p.offset(prime_ * 208 + 22) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 22) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 22) < end);
                                                                 *p.offset(prime_ * 208 + 22) &= 253;
 
-                                                                p = p.offset(prime_ * 210 + 29)
+                                                                p = (p as usize).saturating_add(prime * 210 + 29) as *mut u8;
                                                             }
                                                             if p >= end { wi = 288; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 191; p = p.offset(prime_ * 10 + 8);
+                                                            *p &= 191; p = (p as usize).saturating_add(prime * 10 + 8) as *mut u8;
                                                             break 'label289
                                                            }
                                                            if p >= end { wi = 289; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 247; p = p.offset(prime_ * 2 + 1);
+                                                           *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                            break 'label290
                                                           }
                                                           if p >= end { wi = 290; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 127; p = p.offset(prime_ * 4 + 4);
+                                                          *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                                           break 'label291
                                                          }
                                                          if p >= end { wi = 291; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 254; p = p.offset(prime_ * 2 + 1);
+                                                         *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                          break 'label292
                                                         }
                                                         if p >= end { wi = 292; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 239; p = p.offset(prime_ * 4 + 3);
+                                                        *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                                         break 'label293
                                                        }
                                                        if p >= end { wi = 293; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 223; p = p.offset(prime_ * 6 + 5);
+                                                       *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                                        break 'label294
                                                       }
                                                       if p >= end { wi = 294; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 253; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label295
                                                      }
                                                      if p >= end { wi = 295; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 191; p = p.offset(prime_ * 6 + 5);
+                                                     *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                                      break 'label296
                                                     }
                                                     if p >= end { wi = 296; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 251; p = p.offset(prime_ * 4 + 3);
+                                                    *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                                     break 'label297
                                                    }
                                                    if p >= end { wi = 297; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 247; p = p.offset(prime_ * 2 + 1);
+                                                   *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                    break 'label298
                                                   }
                                                   if p >= end { wi = 298; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 127; p = p.offset(prime_ * 4 + 4);
+                                                  *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                                   break 'label299
                                                  }
                                                  if p >= end { wi = 299; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 254; p = p.offset(prime_ * 6 + 4);
+                                                 *p &= 254; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                                                  break 'label300
                                                 }
                                                 if p >= end { wi = 300; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 223; p = p.offset(prime_ * 6 + 5);
+                                                *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                                 break 'label301
                                                }
                                                if p >= end { wi = 301; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 253; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label302
                                               }
                                               if p >= end { wi = 302; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 191; p = p.offset(prime_ * 6 + 5);
+                                              *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                               break 'label303
                                              }
                                              if p >= end { wi = 303; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 251; p = p.offset(prime_ * 4 + 3);
+                                             *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                              break 'label304
                                             }
                                             if p >= end { wi = 304; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 247; p = p.offset(prime_ * 2 + 1);
+                                            *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                             break 'label305
                                            }
                                            if p >= end { wi = 305; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 127; p = p.offset(prime_ * 6 + 5);
+                                           *p &= 127; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                            break 'label306
                                           }
                                           if p >= end { wi = 306; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 239; p = p.offset(prime_ * 4 + 3);
+                                          *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                           break 'label307
                                          }
                                          if p >= end { wi = 307; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 223; p = p.offset(prime_ * 6 + 5);
+                                         *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                          break 'label308
                                         }
                                         if p >= end { wi = 308; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 253; p = p.offset(prime_ * 8 + 6);
+                                        *p &= 253; p = (p as usize).saturating_add(prime * 8 + 6) as *mut u8;
                                         break 'label309
                                        }
                                        if p >= end { wi = 309; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 251; p = p.offset(prime_ * 4 + 3);
+                                       *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                        break 'label310
                                       }
                                       if p >= end { wi = 310; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 247; p = p.offset(prime_ * 2 + 1);
+                                      *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                       break 'label311
                                      }
                                      if p >= end { wi = 311; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 127; p = p.offset(prime_ * 4 + 4);
+                                     *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                      break 'label312
                                     }
                                     if p >= end { wi = 312; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 254; p = p.offset(prime_ * 2 + 1);
+                                    *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                     break 'label313
                                    }
                                    if p >= end { wi = 313; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 239; p = p.offset(prime_ * 4 + 3);
+                                   *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                    break 'label314
                                   }
                                   if p >= end { wi = 314; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 223; p = p.offset(prime_ * 8 + 6);
+                                  *p &= 223; p = (p as usize).saturating_add(prime * 8 + 6) as *mut u8;
                                   break 'label315
                                  }
                                  if p >= end { wi = 315; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 191; p = p.offset(prime_ * 6 + 5);
+                                 *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                  break 'label316
                                 }
                                 if p >= end { wi = 316; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 251; p = p.offset(prime_ * 4 + 3);
+                                *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                                 break 'label317
                                }
                                if p >= end { wi = 317; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 247; p = p.offset(prime_ * 6 + 5);
+                               *p &= 247; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                                break 'label318
                               }
                               if p >= end { wi = 318; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 254; p = p.offset(prime_ * 2 + 1);
+                              *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                               break 'label319
                              }
                              if p >= end { wi = 319; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 239; p = p.offset(prime_ * 4 + 3);
+                             *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                              break 'label320
                             }
                             if p >= end { wi = 320; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 223; p = p.offset(prime_ * 6 + 5);
+                            *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                             break 'label321
                            }
                            if p >= end { wi = 321; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 253; p = p.offset(prime_ * 2 + 1);
+                           *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label322
                           }
                           if p >= end { wi = 322; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 191; p = p.offset(prime_ * 6 + 5);
+                          *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                           break 'label323
                          }
                          if p >= end { wi = 323; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 251; p = p.offset(prime_ * 6 + 4);
+                         *p &= 251; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                          break 'label324
                         }
                         if p >= end { wi = 324; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 127; p = p.offset(prime_ * 4 + 4);
+                        *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                         break 'label325
                        }
                        if p >= end { wi = 325; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 254; p = p.offset(prime_ * 2 + 1);
+                       *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                        break 'label326
                       }
                       if p >= end { wi = 326; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 239; p = p.offset(prime_ * 4 + 3);
+                      *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                       break 'label327
                      }
                      if p >= end { wi = 327; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 223; p = p.offset(prime_ * 6 + 5);
+                     *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                      break 'label328
                     }
                     if p >= end { wi = 328; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 253; p = p.offset(prime_ * 2 + 1);
+                    *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label329
                    }
                    if p >= end { wi = 329; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 191; p = p.offset(prime_ * 6 + 5);
+                   *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                    break 'label330
                   }
                   if p >= end { wi = 330; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 251; p = p.offset(prime_ * 4 + 3);
+                  *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                   break 'label331
                  }
                  if p >= end { wi = 331; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 247; p = p.offset(prime_ * 2 + 1);
+                 *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                  break 'label332
                 }
                 if p >= end { wi = 332; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 127; p = p.offset(prime_ * 4 + 4);
+                *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                 break 'label333
                }
                if p >= end { wi = 333; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 254; p = p.offset(prime_ * 2 + 1);
+               *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                break 'label334
               }
               if p >= end { wi = 334; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 239; p = p.offset(prime_ * 10 + 8);
+              *p &= 239; p = (p as usize).saturating_add(prime * 10 + 8) as *mut u8;
               break 'label335
              }
              if p >= end { wi = 335; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 253; p = p.offset(prime_ * 2 + 1);
+             *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 288
             }
         }
@@ -4230,391 +4230,391 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                                             }
                                                             while p < loop_end {
                                                                 p = crate::b(p);
-                                                                safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                                                             p.offset(prime_ * 0 + 0) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                                                             p.wrapping_offset(prime_ * 0 + 0) < end);
                                                                 *p.offset(prime_ * 0 + 0) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 10 + 1) &&
-                                                                             p.offset(prime_ * 10 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 10 + 1) < end);
                                                                 *p.offset(prime_ * 10 + 1) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 12 + 1) &&
-                                                                             p.offset(prime_ * 12 + 1) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 1) &&
+                                                                             p.wrapping_offset(prime_ * 12 + 1) < end);
                                                                 *p.offset(prime_ * 12 + 1) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 16 + 2) &&
-                                                                             p.offset(prime_ * 16 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 16 + 2) < end);
                                                                 *p.offset(prime_ * 16 + 2) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 18 + 2) &&
-                                                                             p.offset(prime_ * 18 + 2) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 2) &&
+                                                                             p.wrapping_offset(prime_ * 18 + 2) < end);
                                                                 *p.offset(prime_ * 18 + 2) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 22 + 3) &&
-                                                                             p.offset(prime_ * 22 + 3) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 3) &&
+                                                                             p.wrapping_offset(prime_ * 22 + 3) < end);
                                                                 *p.offset(prime_ * 22 + 3) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 28 + 4) &&
-                                                                             p.offset(prime_ * 28 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 28 + 4) < end);
                                                                 *p.offset(prime_ * 28 + 4) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 30 + 4) &&
-                                                                             p.offset(prime_ * 30 + 4) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 30 + 4) &&
+                                                                             p.wrapping_offset(prime_ * 30 + 4) < end);
                                                                 *p.offset(prime_ * 30 + 4) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 36 + 5) &&
-                                                                             p.offset(prime_ * 36 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 36 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 36 + 5) < end);
                                                                 *p.offset(prime_ * 36 + 5) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 40 + 5) &&
-                                                                             p.offset(prime_ * 40 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 40 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 40 + 5) < end);
                                                                 *p.offset(prime_ * 40 + 5) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 42 + 5) &&
-                                                                             p.offset(prime_ * 42 + 5) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 42 + 5) &&
+                                                                             p.wrapping_offset(prime_ * 42 + 5) < end);
                                                                 *p.offset(prime_ * 42 + 5) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 46 + 6) &&
-                                                                             p.offset(prime_ * 46 + 6) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 46 + 6) &&
+                                                                             p.wrapping_offset(prime_ * 46 + 6) < end);
                                                                 *p.offset(prime_ * 46 + 6) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 52 + 7) &&
-                                                                             p.offset(prime_ * 52 + 7) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 52 + 7) &&
+                                                                             p.wrapping_offset(prime_ * 52 + 7) < end);
                                                                 *p.offset(prime_ * 52 + 7) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 58 + 8) &&
-                                                                             p.offset(prime_ * 58 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 58 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 58 + 8) < end);
                                                                 *p.offset(prime_ * 58 + 8) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 60 + 8) &&
-                                                                             p.offset(prime_ * 60 + 8) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 60 + 8) &&
+                                                                             p.wrapping_offset(prime_ * 60 + 8) < end);
                                                                 *p.offset(prime_ * 60 + 8) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 66 + 9) &&
-                                                                             p.offset(prime_ * 66 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 66 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 66 + 9) < end);
                                                                 *p.offset(prime_ * 66 + 9) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 70 + 9) &&
-                                                                             p.offset(prime_ * 70 + 9) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 70 + 9) &&
+                                                                             p.wrapping_offset(prime_ * 70 + 9) < end);
                                                                 *p.offset(prime_ * 70 + 9) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 72 + 10) &&
-                                                                             p.offset(prime_ * 72 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 72 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 72 + 10) < end);
                                                                 *p.offset(prime_ * 72 + 10) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 78 + 10) &&
-                                                                             p.offset(prime_ * 78 + 10) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 78 + 10) &&
+                                                                             p.wrapping_offset(prime_ * 78 + 10) < end);
                                                                 *p.offset(prime_ * 78 + 10) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 82 + 11) &&
-                                                                             p.offset(prime_ * 82 + 11) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 82 + 11) &&
+                                                                             p.wrapping_offset(prime_ * 82 + 11) < end);
                                                                 *p.offset(prime_ * 82 + 11) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 88 + 12) &&
-                                                                             p.offset(prime_ * 88 + 12) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 88 + 12) &&
+                                                                             p.wrapping_offset(prime_ * 88 + 12) < end);
                                                                 *p.offset(prime_ * 88 + 12) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 96 + 13) &&
-                                                                             p.offset(prime_ * 96 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 96 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 96 + 13) < end);
                                                                 *p.offset(prime_ * 96 + 13) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 100 + 13) &&
-                                                                             p.offset(prime_ * 100 + 13) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 100 + 13) &&
+                                                                             p.wrapping_offset(prime_ * 100 + 13) < end);
                                                                 *p.offset(prime_ * 100 + 13) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 102 + 14) &&
-                                                                             p.offset(prime_ * 102 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 102 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 102 + 14) < end);
                                                                 *p.offset(prime_ * 102 + 14) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 106 + 14) &&
-                                                                             p.offset(prime_ * 106 + 14) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 106 + 14) &&
+                                                                             p.wrapping_offset(prime_ * 106 + 14) < end);
                                                                 *p.offset(prime_ * 106 + 14) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 108 + 15) &&
-                                                                             p.offset(prime_ * 108 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 108 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 108 + 15) < end);
                                                                 *p.offset(prime_ * 108 + 15) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 112 + 15) &&
-                                                                             p.offset(prime_ * 112 + 15) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 112 + 15) &&
+                                                                             p.wrapping_offset(prime_ * 112 + 15) < end);
                                                                 *p.offset(prime_ * 112 + 15) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 120 + 16) &&
-                                                                             p.offset(prime_ * 120 + 16) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 120 + 16) &&
+                                                                             p.wrapping_offset(prime_ * 120 + 16) < end);
                                                                 *p.offset(prime_ * 120 + 16) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 126 + 17) &&
-                                                                             p.offset(prime_ * 126 + 17) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 126 + 17) &&
+                                                                             p.wrapping_offset(prime_ * 126 + 17) < end);
                                                                 *p.offset(prime_ * 126 + 17) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 130 + 18) &&
-                                                                             p.offset(prime_ * 130 + 18) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 130 + 18) &&
+                                                                             p.wrapping_offset(prime_ * 130 + 18) < end);
                                                                 *p.offset(prime_ * 130 + 18) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 136 + 18) &&
-                                                                             p.offset(prime_ * 136 + 18) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 136 + 18) &&
+                                                                             p.wrapping_offset(prime_ * 136 + 18) < end);
                                                                 *p.offset(prime_ * 136 + 18) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 138 + 19) &&
-                                                                             p.offset(prime_ * 138 + 19) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 138 + 19) &&
+                                                                             p.wrapping_offset(prime_ * 138 + 19) < end);
                                                                 *p.offset(prime_ * 138 + 19) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 142 + 19) &&
-                                                                             p.offset(prime_ * 142 + 19) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 142 + 19) &&
+                                                                             p.wrapping_offset(prime_ * 142 + 19) < end);
                                                                 *p.offset(prime_ * 142 + 19) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 148 + 20) &&
-                                                                             p.offset(prime_ * 148 + 20) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 148 + 20) &&
+                                                                             p.wrapping_offset(prime_ * 148 + 20) < end);
                                                                 *p.offset(prime_ * 148 + 20) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 150 + 20) &&
-                                                                             p.offset(prime_ * 150 + 20) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 150 + 20) &&
+                                                                             p.wrapping_offset(prime_ * 150 + 20) < end);
                                                                 *p.offset(prime_ * 150 + 20) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 156 + 21) &&
-                                                                             p.offset(prime_ * 156 + 21) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 156 + 21) &&
+                                                                             p.wrapping_offset(prime_ * 156 + 21) < end);
                                                                 *p.offset(prime_ * 156 + 21) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 162 + 22) &&
-                                                                             p.offset(prime_ * 162 + 22) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 162 + 22) &&
+                                                                             p.wrapping_offset(prime_ * 162 + 22) < end);
                                                                 *p.offset(prime_ * 162 + 22) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 166 + 23) &&
-                                                                             p.offset(prime_ * 166 + 23) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 166 + 23) &&
+                                                                             p.wrapping_offset(prime_ * 166 + 23) < end);
                                                                 *p.offset(prime_ * 166 + 23) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 168 + 23) &&
-                                                                             p.offset(prime_ * 168 + 23) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 168 + 23) &&
+                                                                             p.wrapping_offset(prime_ * 168 + 23) < end);
                                                                 *p.offset(prime_ * 168 + 23) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 172 + 23) &&
-                                                                             p.offset(prime_ * 172 + 23) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 172 + 23) &&
+                                                                             p.wrapping_offset(prime_ * 172 + 23) < end);
                                                                 *p.offset(prime_ * 172 + 23) &= 253;
-                                                                safe_assert!(start <= p.offset(prime_ * 178 + 24) &&
-                                                                             p.offset(prime_ * 178 + 24) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 178 + 24) &&
+                                                                             p.wrapping_offset(prime_ * 178 + 24) < end);
                                                                 *p.offset(prime_ * 178 + 24) &= 254;
-                                                                safe_assert!(start <= p.offset(prime_ * 180 + 24) &&
-                                                                             p.offset(prime_ * 180 + 24) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 180 + 24) &&
+                                                                             p.wrapping_offset(prime_ * 180 + 24) < end);
                                                                 *p.offset(prime_ * 180 + 24) &= 127;
-                                                                safe_assert!(start <= p.offset(prime_ * 186 + 25) &&
-                                                                             p.offset(prime_ * 186 + 25) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 186 + 25) &&
+                                                                             p.wrapping_offset(prime_ * 186 + 25) < end);
                                                                 *p.offset(prime_ * 186 + 25) &= 191;
-                                                                safe_assert!(start <= p.offset(prime_ * 190 + 26) &&
-                                                                             p.offset(prime_ * 190 + 26) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 190 + 26) &&
+                                                                             p.wrapping_offset(prime_ * 190 + 26) < end);
                                                                 *p.offset(prime_ * 190 + 26) &= 223;
-                                                                safe_assert!(start <= p.offset(prime_ * 192 + 26) &&
-                                                                             p.offset(prime_ * 192 + 26) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 192 + 26) &&
+                                                                             p.wrapping_offset(prime_ * 192 + 26) < end);
                                                                 *p.offset(prime_ * 192 + 26) &= 239;
-                                                                safe_assert!(start <= p.offset(prime_ * 196 + 27) &&
-                                                                             p.offset(prime_ * 196 + 27) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 196 + 27) &&
+                                                                             p.wrapping_offset(prime_ * 196 + 27) < end);
                                                                 *p.offset(prime_ * 196 + 27) &= 247;
-                                                                safe_assert!(start <= p.offset(prime_ * 198 + 27) &&
-                                                                             p.offset(prime_ * 198 + 27) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 198 + 27) &&
+                                                                             p.wrapping_offset(prime_ * 198 + 27) < end);
                                                                 *p.offset(prime_ * 198 + 27) &= 251;
-                                                                safe_assert!(start <= p.offset(prime_ * 208 + 28) &&
-                                                                             p.offset(prime_ * 208 + 28) < end);
+                                                                safe_assert!(start <= p.wrapping_offset(prime_ * 208 + 28) &&
+                                                                             p.wrapping_offset(prime_ * 208 + 28) < end);
                                                                 *p.offset(prime_ * 208 + 28) &= 254;
 
-                                                                p = p.offset(prime_ * 210 + 31)
+                                                                p = (p as usize).saturating_add(prime * 210 + 31) as *mut u8;
                                                             }
                                                             if p >= end { wi = 336; break 'outer; }
                                                             safe_assert!(start <= p && p < end);
-                                                            *p &= 127; p = p.offset(prime_ * 10 + 10);
+                                                            *p &= 127; p = (p as usize).saturating_add(prime * 10 + 10) as *mut u8;
                                                             break 'label337
                                                            }
                                                            if p >= end { wi = 337; break 'outer; }
                                                            safe_assert!(start <= p && p < end);
-                                                           *p &= 223; p = p.offset(prime_ * 2 + 2);
+                                                           *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                                            break 'label338
                                                           }
                                                           if p >= end { wi = 338; break 'outer; }
                                                           safe_assert!(start <= p && p < end);
-                                                          *p &= 239; p = p.offset(prime_ * 4 + 4);
+                                                          *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                                           break 'label339
                                                          }
                                                          if p >= end { wi = 339; break 'outer; }
                                                          safe_assert!(start <= p && p < end);
-                                                         *p &= 247; p = p.offset(prime_ * 2 + 2);
+                                                         *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                                          break 'label340
                                                         }
                                                         if p >= end { wi = 340; break 'outer; }
                                                         safe_assert!(start <= p && p < end);
-                                                        *p &= 251; p = p.offset(prime_ * 4 + 4);
+                                                        *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                                         break 'label341
                                                        }
                                                        if p >= end { wi = 341; break 'outer; }
                                                        safe_assert!(start <= p && p < end);
-                                                       *p &= 253; p = p.offset(prime_ * 6 + 6);
+                                                       *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                                        break 'label342
                                                       }
                                                       if p >= end { wi = 342; break 'outer; }
                                                       safe_assert!(start <= p && p < end);
-                                                      *p &= 254; p = p.offset(prime_ * 2 + 1);
+                                                      *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                       break 'label343
                                                      }
                                                      if p >= end { wi = 343; break 'outer; }
                                                      safe_assert!(start <= p && p < end);
-                                                     *p &= 127; p = p.offset(prime_ * 6 + 6);
+                                                     *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                                      break 'label344
                                                     }
                                                     if p >= end { wi = 344; break 'outer; }
                                                     safe_assert!(start <= p && p < end);
-                                                    *p &= 191; p = p.offset(prime_ * 4 + 4);
+                                                    *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                                     break 'label345
                                                    }
                                                    if p >= end { wi = 345; break 'outer; }
                                                    safe_assert!(start <= p && p < end);
-                                                   *p &= 223; p = p.offset(prime_ * 2 + 2);
+                                                   *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                                    break 'label346
                                                   }
                                                   if p >= end { wi = 346; break 'outer; }
                                                   safe_assert!(start <= p && p < end);
-                                                  *p &= 239; p = p.offset(prime_ * 4 + 4);
+                                                  *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                                   break 'label347
                                                  }
                                                  if p >= end { wi = 347; break 'outer; }
                                                  safe_assert!(start <= p && p < end);
-                                                 *p &= 247; p = p.offset(prime_ * 6 + 6);
+                                                 *p &= 247; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                                  break 'label348
                                                 }
                                                 if p >= end { wi = 348; break 'outer; }
                                                 safe_assert!(start <= p && p < end);
-                                                *p &= 253; p = p.offset(prime_ * 6 + 6);
+                                                *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                                 break 'label349
                                                }
                                                if p >= end { wi = 349; break 'outer; }
                                                safe_assert!(start <= p && p < end);
-                                               *p &= 254; p = p.offset(prime_ * 2 + 1);
+                                               *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                                                break 'label350
                                               }
                                               if p >= end { wi = 350; break 'outer; }
                                               safe_assert!(start <= p && p < end);
-                                              *p &= 127; p = p.offset(prime_ * 6 + 6);
+                                              *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                               break 'label351
                                              }
                                              if p >= end { wi = 351; break 'outer; }
                                              safe_assert!(start <= p && p < end);
-                                             *p &= 191; p = p.offset(prime_ * 4 + 4);
+                                             *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                              break 'label352
                                             }
                                             if p >= end { wi = 352; break 'outer; }
                                             safe_assert!(start <= p && p < end);
-                                            *p &= 223; p = p.offset(prime_ * 2 + 2);
+                                            *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                             break 'label353
                                            }
                                            if p >= end { wi = 353; break 'outer; }
                                            safe_assert!(start <= p && p < end);
-                                           *p &= 239; p = p.offset(prime_ * 6 + 6);
+                                           *p &= 239; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                            break 'label354
                                           }
                                           if p >= end { wi = 354; break 'outer; }
                                           safe_assert!(start <= p && p < end);
-                                          *p &= 251; p = p.offset(prime_ * 4 + 4);
+                                          *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                           break 'label355
                                          }
                                          if p >= end { wi = 355; break 'outer; }
                                          safe_assert!(start <= p && p < end);
-                                         *p &= 253; p = p.offset(prime_ * 6 + 6);
+                                         *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                          break 'label356
                                         }
                                         if p >= end { wi = 356; break 'outer; }
                                         safe_assert!(start <= p && p < end);
-                                        *p &= 254; p = p.offset(prime_ * 8 + 7);
+                                        *p &= 254; p = (p as usize).saturating_add(prime * 8 + 7) as *mut u8;
                                         break 'label357
                                        }
                                        if p >= end { wi = 357; break 'outer; }
                                        safe_assert!(start <= p && p < end);
-                                       *p &= 191; p = p.offset(prime_ * 4 + 4);
+                                       *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                        break 'label358
                                       }
                                       if p >= end { wi = 358; break 'outer; }
                                       safe_assert!(start <= p && p < end);
-                                      *p &= 223; p = p.offset(prime_ * 2 + 2);
+                                      *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                       break 'label359
                                      }
                                      if p >= end { wi = 359; break 'outer; }
                                      safe_assert!(start <= p && p < end);
-                                     *p &= 239; p = p.offset(prime_ * 4 + 4);
+                                     *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                      break 'label360
                                     }
                                     if p >= end { wi = 360; break 'outer; }
                                     safe_assert!(start <= p && p < end);
-                                    *p &= 247; p = p.offset(prime_ * 2 + 2);
+                                    *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                                     break 'label361
                                    }
                                    if p >= end { wi = 361; break 'outer; }
                                    safe_assert!(start <= p && p < end);
-                                   *p &= 251; p = p.offset(prime_ * 4 + 4);
+                                   *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                    break 'label362
                                   }
                                   if p >= end { wi = 362; break 'outer; }
                                   safe_assert!(start <= p && p < end);
-                                  *p &= 253; p = p.offset(prime_ * 8 + 7);
+                                  *p &= 253; p = (p as usize).saturating_add(prime * 8 + 7) as *mut u8;
                                   break 'label363
                                  }
                                  if p >= end { wi = 363; break 'outer; }
                                  safe_assert!(start <= p && p < end);
-                                 *p &= 127; p = p.offset(prime_ * 6 + 6);
+                                 *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                  break 'label364
                                 }
                                 if p >= end { wi = 364; break 'outer; }
                                 safe_assert!(start <= p && p < end);
-                                *p &= 191; p = p.offset(prime_ * 4 + 4);
+                                *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                                 break 'label365
                                }
                                if p >= end { wi = 365; break 'outer; }
                                safe_assert!(start <= p && p < end);
-                               *p &= 223; p = p.offset(prime_ * 6 + 6);
+                               *p &= 223; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                                break 'label366
                               }
                               if p >= end { wi = 366; break 'outer; }
                               safe_assert!(start <= p && p < end);
-                              *p &= 247; p = p.offset(prime_ * 2 + 2);
+                              *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                               break 'label367
                              }
                              if p >= end { wi = 367; break 'outer; }
                              safe_assert!(start <= p && p < end);
-                             *p &= 251; p = p.offset(prime_ * 4 + 4);
+                             *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                              break 'label368
                             }
                             if p >= end { wi = 368; break 'outer; }
                             safe_assert!(start <= p && p < end);
-                            *p &= 253; p = p.offset(prime_ * 6 + 6);
+                            *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                             break 'label369
                            }
                            if p >= end { wi = 369; break 'outer; }
                            safe_assert!(start <= p && p < end);
-                           *p &= 254; p = p.offset(prime_ * 2 + 1);
+                           *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                            break 'label370
                           }
                           if p >= end { wi = 370; break 'outer; }
                           safe_assert!(start <= p && p < end);
-                          *p &= 127; p = p.offset(prime_ * 6 + 6);
+                          *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                           break 'label371
                          }
                          if p >= end { wi = 371; break 'outer; }
                          safe_assert!(start <= p && p < end);
-                         *p &= 191; p = p.offset(prime_ * 6 + 6);
+                         *p &= 191; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                          break 'label372
                         }
                         if p >= end { wi = 372; break 'outer; }
                         safe_assert!(start <= p && p < end);
-                        *p &= 239; p = p.offset(prime_ * 4 + 4);
+                        *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                         break 'label373
                        }
                        if p >= end { wi = 373; break 'outer; }
                        safe_assert!(start <= p && p < end);
-                       *p &= 247; p = p.offset(prime_ * 2 + 2);
+                       *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                        break 'label374
                       }
                       if p >= end { wi = 374; break 'outer; }
                       safe_assert!(start <= p && p < end);
-                      *p &= 251; p = p.offset(prime_ * 4 + 4);
+                      *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                       break 'label375
                      }
                      if p >= end { wi = 375; break 'outer; }
                      safe_assert!(start <= p && p < end);
-                     *p &= 253; p = p.offset(prime_ * 6 + 6);
+                     *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                      break 'label376
                     }
                     if p >= end { wi = 376; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 254; p = p.offset(prime_ * 2 + 1);
+                    *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                     break 'label377
                    }
                    if p >= end { wi = 377; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 127; p = p.offset(prime_ * 6 + 6);
+                   *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                    break 'label378
                   }
                   if p >= end { wi = 378; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 191; p = p.offset(prime_ * 4 + 4);
+                  *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                   break 'label379
                  }
                  if p >= end { wi = 379; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 223; p = p.offset(prime_ * 2 + 2);
+                 *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                  break 'label380
                 }
                 if p >= end { wi = 380; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 239; p = p.offset(prime_ * 4 + 4);
+                *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                 break 'label381
                }
                if p >= end { wi = 381; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 247; p = p.offset(prime_ * 2 + 2);
+               *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                break 'label382
               }
               if p >= end { wi = 382; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 251; p = p.offset(prime_ * 10 + 10);
+              *p &= 251; p = (p as usize).saturating_add(prime * 10 + 10) as *mut u8;
               break 'label383
              }
              if p >= end { wi = 383; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 254; p = p.offset(prime_ * 2 + 1);
+             *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 336
             }
         }

--- a/primal-sieve/src/wheel/wheel30.rs
+++ b/primal-sieve/src/wheel/wheel30.rs
@@ -219,71 +219,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 254;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 0) &&
-                                     p.offset(prime_ * 6 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 0) &&
+                                     p.wrapping_offset(prime_ * 6 + 0) < end);
                         *p.offset(prime_ * 6 + 0) &= 253;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 0) &&
-                                     p.offset(prime_ * 10 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 0) &&
+                                     p.wrapping_offset(prime_ * 10 + 0) < end);
                         *p.offset(prime_ * 10 + 0) &= 251;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 0) &&
-                                     p.offset(prime_ * 12 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 0) &&
+                                     p.wrapping_offset(prime_ * 12 + 0) < end);
                         *p.offset(prime_ * 12 + 0) &= 247;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 0) &&
-                                     p.offset(prime_ * 16 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 0) &&
+                                     p.wrapping_offset(prime_ * 16 + 0) < end);
                         *p.offset(prime_ * 16 + 0) &= 239;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 0) &&
-                                     p.offset(prime_ * 18 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 0) &&
+                                     p.wrapping_offset(prime_ * 18 + 0) < end);
                         *p.offset(prime_ * 18 + 0) &= 223;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 0) &&
-                                     p.offset(prime_ * 22 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 0) &&
+                                     p.wrapping_offset(prime_ * 22 + 0) < end);
                         *p.offset(prime_ * 22 + 0) &= 191;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 0) &&
-                                     p.offset(prime_ * 28 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 0) &&
+                                     p.wrapping_offset(prime_ * 28 + 0) < end);
                         *p.offset(prime_ * 28 + 0) &= 127;
 
-                        p = p.offset(prime_ * 30 + 1)
+                        p = (p as usize).saturating_add(prime * 30 + 1) as *mut u8;
                     }
                     if p >= end { wi = 0; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 254; p = p.offset(prime_ * 6 + 0);
+                    *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
                     break 'label1
                    }
                    if p >= end { wi = 1; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 253; p = p.offset(prime_ * 4 + 0);
+                   *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                    break 'label2
                   }
                   if p >= end { wi = 2; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 251; p = p.offset(prime_ * 2 + 0);
+                  *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                   break 'label3
                  }
                  if p >= end { wi = 3; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 247; p = p.offset(prime_ * 4 + 0);
+                 *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                  break 'label4
                 }
                 if p >= end { wi = 4; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 239; p = p.offset(prime_ * 2 + 0);
+                *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                 break 'label5
                }
                if p >= end { wi = 5; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 223; p = p.offset(prime_ * 4 + 0);
+               *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                break 'label6
               }
               if p >= end { wi = 6; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 191; p = p.offset(prime_ * 6 + 0);
+              *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
               break 'label7
              }
              if p >= end { wi = 7; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 127; p = p.offset(prime_ * 2 + 1);
+             *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 0
             }
         }
@@ -310,71 +310,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 253;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 1) &&
-                                     p.offset(prime_ * 6 + 1) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 1) &&
+                                     p.wrapping_offset(prime_ * 6 + 1) < end);
                         *p.offset(prime_ * 6 + 1) &= 223;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 2) &&
-                                     p.offset(prime_ * 10 + 2) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 2) &&
+                                     p.wrapping_offset(prime_ * 10 + 2) < end);
                         *p.offset(prime_ * 10 + 2) &= 239;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 3) &&
-                                     p.offset(prime_ * 12 + 3) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 3) &&
+                                     p.wrapping_offset(prime_ * 12 + 3) < end);
                         *p.offset(prime_ * 12 + 3) &= 254;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 3) &&
-                                     p.offset(prime_ * 16 + 3) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 3) &&
+                                     p.wrapping_offset(prime_ * 16 + 3) < end);
                         *p.offset(prime_ * 16 + 3) &= 127;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 4) &&
-                                     p.offset(prime_ * 18 + 4) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 4) &&
+                                     p.wrapping_offset(prime_ * 18 + 4) < end);
                         *p.offset(prime_ * 18 + 4) &= 247;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 5) &&
-                                     p.offset(prime_ * 22 + 5) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 5) &&
+                                     p.wrapping_offset(prime_ * 22 + 5) < end);
                         *p.offset(prime_ * 22 + 5) &= 251;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 6) &&
-                                     p.offset(prime_ * 28 + 6) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 6) &&
+                                     p.wrapping_offset(prime_ * 28 + 6) < end);
                         *p.offset(prime_ * 28 + 6) &= 191;
 
-                        p = p.offset(prime_ * 30 + 7)
+                        p = (p as usize).saturating_add(prime * 30 + 7) as *mut u8;
                     }
                     if p >= end { wi = 8; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 253; p = p.offset(prime_ * 6 + 1);
+                    *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
                     break 'label9
                    }
                    if p >= end { wi = 9; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 223; p = p.offset(prime_ * 4 + 1);
+                   *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                    break 'label10
                   }
                   if p >= end { wi = 10; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 239; p = p.offset(prime_ * 2 + 1);
+                  *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                   break 'label11
                  }
                  if p >= end { wi = 11; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 254; p = p.offset(prime_ * 4 + 0);
+                 *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
                  break 'label12
                 }
                 if p >= end { wi = 12; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 127; p = p.offset(prime_ * 2 + 1);
+                *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                 break 'label13
                }
                if p >= end { wi = 13; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 247; p = p.offset(prime_ * 4 + 1);
+               *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                break 'label14
               }
               if p >= end { wi = 14; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 251; p = p.offset(prime_ * 6 + 1);
+              *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
               break 'label15
              }
              if p >= end { wi = 15; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 191; p = p.offset(prime_ * 2 + 1);
+             *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 8
             }
         }
@@ -401,71 +401,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 251;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 2) &&
-                                     p.offset(prime_ * 6 + 2) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 2) &&
+                                     p.wrapping_offset(prime_ * 6 + 2) < end);
                         *p.offset(prime_ * 6 + 2) &= 239;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 4) &&
-                                     p.offset(prime_ * 10 + 4) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 4) &&
+                                     p.wrapping_offset(prime_ * 10 + 4) < end);
                         *p.offset(prime_ * 10 + 4) &= 254;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 4) &&
-                                     p.offset(prime_ * 12 + 4) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 4) &&
+                                     p.wrapping_offset(prime_ * 12 + 4) < end);
                         *p.offset(prime_ * 12 + 4) &= 191;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 6) &&
-                                     p.offset(prime_ * 16 + 6) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 6) &&
+                                     p.wrapping_offset(prime_ * 16 + 6) < end);
                         *p.offset(prime_ * 16 + 6) &= 253;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 6) &&
-                                     p.offset(prime_ * 18 + 6) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 6) &&
+                                     p.wrapping_offset(prime_ * 18 + 6) < end);
                         *p.offset(prime_ * 18 + 6) &= 127;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 8) &&
-                                     p.offset(prime_ * 22 + 8) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 8) &&
+                                     p.wrapping_offset(prime_ * 22 + 8) < end);
                         *p.offset(prime_ * 22 + 8) &= 247;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 10) &&
-                                     p.offset(prime_ * 28 + 10) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 10) &&
+                                     p.wrapping_offset(prime_ * 28 + 10) < end);
                         *p.offset(prime_ * 28 + 10) &= 223;
 
-                        p = p.offset(prime_ * 30 + 11)
+                        p = (p as usize).saturating_add(prime * 30 + 11) as *mut u8;
                     }
                     if p >= end { wi = 16; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 251; p = p.offset(prime_ * 6 + 2);
+                    *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
                     break 'label17
                    }
                    if p >= end { wi = 17; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 239; p = p.offset(prime_ * 4 + 2);
+                   *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                    break 'label18
                   }
                   if p >= end { wi = 18; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 254; p = p.offset(prime_ * 2 + 0);
+                  *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                   break 'label19
                  }
                  if p >= end { wi = 19; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 191; p = p.offset(prime_ * 4 + 2);
+                 *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                  break 'label20
                 }
                 if p >= end { wi = 20; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 253; p = p.offset(prime_ * 2 + 0);
+                *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
                 break 'label21
                }
                if p >= end { wi = 21; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 127; p = p.offset(prime_ * 4 + 2);
+               *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                break 'label22
               }
               if p >= end { wi = 22; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 247; p = p.offset(prime_ * 6 + 2);
+              *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
               break 'label23
              }
              if p >= end { wi = 23; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 223; p = p.offset(prime_ * 2 + 1);
+             *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 16
             }
         }
@@ -492,71 +492,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 247;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 3) &&
-                                     p.offset(prime_ * 6 + 3) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 3) &&
+                                     p.wrapping_offset(prime_ * 6 + 3) < end);
                         *p.offset(prime_ * 6 + 3) &= 254;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 4) &&
-                                     p.offset(prime_ * 10 + 4) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 4) &&
+                                     p.wrapping_offset(prime_ * 10 + 4) < end);
                         *p.offset(prime_ * 10 + 4) &= 191;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 5) &&
-                                     p.offset(prime_ * 12 + 5) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 5) &&
+                                     p.wrapping_offset(prime_ * 12 + 5) < end);
                         *p.offset(prime_ * 12 + 5) &= 223;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 7) &&
-                                     p.offset(prime_ * 16 + 7) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 7) &&
+                                     p.wrapping_offset(prime_ * 16 + 7) < end);
                         *p.offset(prime_ * 16 + 7) &= 251;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 8) &&
-                                     p.offset(prime_ * 18 + 8) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 8) &&
+                                     p.wrapping_offset(prime_ * 18 + 8) < end);
                         *p.offset(prime_ * 18 + 8) &= 253;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 9) &&
-                                     p.offset(prime_ * 22 + 9) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 9) &&
+                                     p.wrapping_offset(prime_ * 22 + 9) < end);
                         *p.offset(prime_ * 22 + 9) &= 127;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 12) &&
-                                     p.offset(prime_ * 28 + 12) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 12) &&
+                                     p.wrapping_offset(prime_ * 28 + 12) < end);
                         *p.offset(prime_ * 28 + 12) &= 239;
 
-                        p = p.offset(prime_ * 30 + 13)
+                        p = (p as usize).saturating_add(prime * 30 + 13) as *mut u8;
                     }
                     if p >= end { wi = 24; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 247; p = p.offset(prime_ * 6 + 3);
+                    *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                     break 'label25
                    }
                    if p >= end { wi = 25; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 254; p = p.offset(prime_ * 4 + 1);
+                   *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                    break 'label26
                   }
                   if p >= end { wi = 26; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 191; p = p.offset(prime_ * 2 + 1);
+                  *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                   break 'label27
                  }
                  if p >= end { wi = 27; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 223; p = p.offset(prime_ * 4 + 2);
+                 *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                  break 'label28
                 }
                 if p >= end { wi = 28; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 251; p = p.offset(prime_ * 2 + 1);
+                *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                 break 'label29
                }
                if p >= end { wi = 29; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 253; p = p.offset(prime_ * 4 + 1);
+               *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
                break 'label30
               }
               if p >= end { wi = 30; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 127; p = p.offset(prime_ * 6 + 3);
+              *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
               break 'label31
              }
              if p >= end { wi = 31; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 239; p = p.offset(prime_ * 2 + 1);
+             *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 24
             }
         }
@@ -583,71 +583,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 239;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 3) &&
-                                     p.offset(prime_ * 6 + 3) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 3) &&
+                                     p.wrapping_offset(prime_ * 6 + 3) < end);
                         *p.offset(prime_ * 6 + 3) &= 127;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 6) &&
-                                     p.offset(prime_ * 10 + 6) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 6) &&
+                                     p.wrapping_offset(prime_ * 10 + 6) < end);
                         *p.offset(prime_ * 10 + 6) &= 253;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 7) &&
-                                     p.offset(prime_ * 12 + 7) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 7) &&
+                                     p.wrapping_offset(prime_ * 12 + 7) < end);
                         *p.offset(prime_ * 12 + 7) &= 251;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 9) &&
-                                     p.offset(prime_ * 16 + 9) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 9) &&
+                                     p.wrapping_offset(prime_ * 16 + 9) < end);
                         *p.offset(prime_ * 16 + 9) &= 223;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 10) &&
-                                     p.offset(prime_ * 18 + 10) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 10) &&
+                                     p.wrapping_offset(prime_ * 18 + 10) < end);
                         *p.offset(prime_ * 18 + 10) &= 191;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 13) &&
-                                     p.offset(prime_ * 22 + 13) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 13) &&
+                                     p.wrapping_offset(prime_ * 22 + 13) < end);
                         *p.offset(prime_ * 22 + 13) &= 254;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 16) &&
-                                     p.offset(prime_ * 28 + 16) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 16) &&
+                                     p.wrapping_offset(prime_ * 28 + 16) < end);
                         *p.offset(prime_ * 28 + 16) &= 247;
 
-                        p = p.offset(prime_ * 30 + 17)
+                        p = (p as usize).saturating_add(prime * 30 + 17) as *mut u8;
                     }
                     if p >= end { wi = 32; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 239; p = p.offset(prime_ * 6 + 3);
+                    *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
                     break 'label33
                    }
                    if p >= end { wi = 33; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 127; p = p.offset(prime_ * 4 + 3);
+                   *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                    break 'label34
                   }
                   if p >= end { wi = 34; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 253; p = p.offset(prime_ * 2 + 1);
+                  *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                   break 'label35
                  }
                  if p >= end { wi = 35; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 251; p = p.offset(prime_ * 4 + 2);
+                 *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                  break 'label36
                 }
                 if p >= end { wi = 36; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 223; p = p.offset(prime_ * 2 + 1);
+                *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                 break 'label37
                }
                if p >= end { wi = 37; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 191; p = p.offset(prime_ * 4 + 3);
+               *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                break 'label38
               }
               if p >= end { wi = 38; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 254; p = p.offset(prime_ * 6 + 3);
+              *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
               break 'label39
              }
              if p >= end { wi = 39; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 247; p = p.offset(prime_ * 2 + 1);
+             *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 32
             }
         }
@@ -674,71 +674,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 223;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 4) &&
-                                     p.offset(prime_ * 6 + 4) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 4) &&
+                                     p.wrapping_offset(prime_ * 6 + 4) < end);
                         *p.offset(prime_ * 6 + 4) &= 247;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 6) &&
-                                     p.offset(prime_ * 10 + 6) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 6) &&
+                                     p.wrapping_offset(prime_ * 10 + 6) < end);
                         *p.offset(prime_ * 10 + 6) &= 127;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 8) &&
-                                     p.offset(prime_ * 12 + 8) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 8) &&
+                                     p.wrapping_offset(prime_ * 12 + 8) < end);
                         *p.offset(prime_ * 12 + 8) &= 253;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 10) &&
-                                     p.offset(prime_ * 16 + 10) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 10) &&
+                                     p.wrapping_offset(prime_ * 16 + 10) < end);
                         *p.offset(prime_ * 16 + 10) &= 191;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 12) &&
-                                     p.offset(prime_ * 18 + 12) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 12) &&
+                                     p.wrapping_offset(prime_ * 18 + 12) < end);
                         *p.offset(prime_ * 18 + 12) &= 254;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 14) &&
-                                     p.offset(prime_ * 22 + 14) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 14) &&
+                                     p.wrapping_offset(prime_ * 22 + 14) < end);
                         *p.offset(prime_ * 22 + 14) &= 239;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 18) &&
-                                     p.offset(prime_ * 28 + 18) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 18) &&
+                                     p.wrapping_offset(prime_ * 28 + 18) < end);
                         *p.offset(prime_ * 28 + 18) &= 251;
 
-                        p = p.offset(prime_ * 30 + 19)
+                        p = (p as usize).saturating_add(prime * 30 + 19) as *mut u8;
                     }
                     if p >= end { wi = 40; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 223; p = p.offset(prime_ * 6 + 4);
+                    *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
                     break 'label41
                    }
                    if p >= end { wi = 41; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 247; p = p.offset(prime_ * 4 + 2);
+                   *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                    break 'label42
                   }
                   if p >= end { wi = 42; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 127; p = p.offset(prime_ * 2 + 2);
+                  *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                   break 'label43
                  }
                  if p >= end { wi = 43; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 253; p = p.offset(prime_ * 4 + 2);
+                 *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                  break 'label44
                 }
                 if p >= end { wi = 44; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 191; p = p.offset(prime_ * 2 + 2);
+                *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                 break 'label45
                }
                if p >= end { wi = 45; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 254; p = p.offset(prime_ * 4 + 2);
+               *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
                break 'label46
               }
               if p >= end { wi = 46; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 239; p = p.offset(prime_ * 6 + 4);
+              *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
               break 'label47
              }
              if p >= end { wi = 47; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 251; p = p.offset(prime_ * 2 + 1);
+             *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 40
             }
         }
@@ -765,71 +765,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 191;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 5) &&
-                                     p.offset(prime_ * 6 + 5) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 5) &&
+                                     p.wrapping_offset(prime_ * 6 + 5) < end);
                         *p.offset(prime_ * 6 + 5) &= 251;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 8) &&
-                                     p.offset(prime_ * 10 + 8) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 8) &&
+                                     p.wrapping_offset(prime_ * 10 + 8) < end);
                         *p.offset(prime_ * 10 + 8) &= 247;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 9) &&
-                                     p.offset(prime_ * 12 + 9) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 9) &&
+                                     p.wrapping_offset(prime_ * 12 + 9) < end);
                         *p.offset(prime_ * 12 + 9) &= 127;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 13) &&
-                                     p.offset(prime_ * 16 + 13) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 13) &&
+                                     p.wrapping_offset(prime_ * 16 + 13) < end);
                         *p.offset(prime_ * 16 + 13) &= 254;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 14) &&
-                                     p.offset(prime_ * 18 + 14) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 14) &&
+                                     p.wrapping_offset(prime_ * 18 + 14) < end);
                         *p.offset(prime_ * 18 + 14) &= 239;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 17) &&
-                                     p.offset(prime_ * 22 + 17) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 17) &&
+                                     p.wrapping_offset(prime_ * 22 + 17) < end);
                         *p.offset(prime_ * 22 + 17) &= 223;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 22) &&
-                                     p.offset(prime_ * 28 + 22) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 22) &&
+                                     p.wrapping_offset(prime_ * 28 + 22) < end);
                         *p.offset(prime_ * 28 + 22) &= 253;
 
-                        p = p.offset(prime_ * 30 + 23)
+                        p = (p as usize).saturating_add(prime * 30 + 23) as *mut u8;
                     }
                     if p >= end { wi = 48; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 191; p = p.offset(prime_ * 6 + 5);
+                    *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
                     break 'label49
                    }
                    if p >= end { wi = 49; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 251; p = p.offset(prime_ * 4 + 3);
+                   *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                    break 'label50
                   }
                   if p >= end { wi = 50; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 247; p = p.offset(prime_ * 2 + 1);
+                  *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                   break 'label51
                  }
                  if p >= end { wi = 51; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 127; p = p.offset(prime_ * 4 + 4);
+                 *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                  break 'label52
                 }
                 if p >= end { wi = 52; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 254; p = p.offset(prime_ * 2 + 1);
+                *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
                 break 'label53
                }
                if p >= end { wi = 53; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 239; p = p.offset(prime_ * 4 + 3);
+               *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
                break 'label54
               }
               if p >= end { wi = 54; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 223; p = p.offset(prime_ * 6 + 5);
+              *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
               break 'label55
              }
              if p >= end { wi = 55; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 253; p = p.offset(prime_ * 2 + 1);
+             *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 48
             }
         }
@@ -856,71 +856,71 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                     }
                     while p < loop_end {
                         p = crate::b(p);
-                        safe_assert!(start <= p.offset(prime_ * 0 + 0) &&
-                                     p.offset(prime_ * 0 + 0) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 0 + 0) &&
+                                     p.wrapping_offset(prime_ * 0 + 0) < end);
                         *p.offset(prime_ * 0 + 0) &= 127;
-                        safe_assert!(start <= p.offset(prime_ * 6 + 6) &&
-                                     p.offset(prime_ * 6 + 6) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 6 + 6) &&
+                                     p.wrapping_offset(prime_ * 6 + 6) < end);
                         *p.offset(prime_ * 6 + 6) &= 191;
-                        safe_assert!(start <= p.offset(prime_ * 10 + 10) &&
-                                     p.offset(prime_ * 10 + 10) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 10 + 10) &&
+                                     p.wrapping_offset(prime_ * 10 + 10) < end);
                         *p.offset(prime_ * 10 + 10) &= 223;
-                        safe_assert!(start <= p.offset(prime_ * 12 + 12) &&
-                                     p.offset(prime_ * 12 + 12) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 12 + 12) &&
+                                     p.wrapping_offset(prime_ * 12 + 12) < end);
                         *p.offset(prime_ * 12 + 12) &= 239;
-                        safe_assert!(start <= p.offset(prime_ * 16 + 16) &&
-                                     p.offset(prime_ * 16 + 16) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 16 + 16) &&
+                                     p.wrapping_offset(prime_ * 16 + 16) < end);
                         *p.offset(prime_ * 16 + 16) &= 247;
-                        safe_assert!(start <= p.offset(prime_ * 18 + 18) &&
-                                     p.offset(prime_ * 18 + 18) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 18 + 18) &&
+                                     p.wrapping_offset(prime_ * 18 + 18) < end);
                         *p.offset(prime_ * 18 + 18) &= 251;
-                        safe_assert!(start <= p.offset(prime_ * 22 + 22) &&
-                                     p.offset(prime_ * 22 + 22) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 22 + 22) &&
+                                     p.wrapping_offset(prime_ * 22 + 22) < end);
                         *p.offset(prime_ * 22 + 22) &= 253;
-                        safe_assert!(start <= p.offset(prime_ * 28 + 28) &&
-                                     p.offset(prime_ * 28 + 28) < end);
+                        safe_assert!(start <= p.wrapping_offset(prime_ * 28 + 28) &&
+                                     p.wrapping_offset(prime_ * 28 + 28) < end);
                         *p.offset(prime_ * 28 + 28) &= 254;
 
-                        p = p.offset(prime_ * 30 + 29)
+                        p = (p as usize).saturating_add(prime * 30 + 29) as *mut u8;
                     }
                     if p >= end { wi = 56; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 127; p = p.offset(prime_ * 6 + 6);
+                    *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
                     break 'label57
                    }
                    if p >= end { wi = 57; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 191; p = p.offset(prime_ * 4 + 4);
+                   *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                    break 'label58
                   }
                   if p >= end { wi = 58; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 223; p = p.offset(prime_ * 2 + 2);
+                  *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                   break 'label59
                  }
                  if p >= end { wi = 59; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 239; p = p.offset(prime_ * 4 + 4);
+                 *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                  break 'label60
                 }
                 if p >= end { wi = 60; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 247; p = p.offset(prime_ * 2 + 2);
+                *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
                 break 'label61
                }
                if p >= end { wi = 61; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 251; p = p.offset(prime_ * 4 + 4);
+               *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
                break 'label62
               }
               if p >= end { wi = 62; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 253; p = p.offset(prime_ * 6 + 6);
+              *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
               break 'label63
              }
              if p >= end { wi = 63; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 254; p = p.offset(prime_ * 2 + 1);
+             *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
              wi = 56
             }
         }

--- a/primal-sieve/src/wheel/wheel30.rs
+++ b/primal-sieve/src/wheel/wheel30.rs
@@ -244,46 +244,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 0) < end);
                         *p.offset(prime_ * 28 + 0) &= 127;
 
-                        p = (p as usize).saturating_add(prime * 30 + 1) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 1);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 0; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 254; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+                    *p &= 254;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 0);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label1
                    }
                    if p >= end { wi = 1; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 253; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                   *p &= 253;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label2
                   }
                   if p >= end { wi = 2; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 251; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                  *p &= 251;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label3
                  }
                  if p >= end { wi = 3; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 247; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                 *p &= 247;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label4
                 }
                 if p >= end { wi = 4; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 239; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                *p &= 239;
+                let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                p = if p <= p2 { p2 } else { end };
                 break 'label5
                }
                if p >= end { wi = 5; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 223; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+               *p &= 223;
+               let p2 = p.wrapping_offset(prime_ * 4 + 0);
+               p = if p <= p2 { p2 } else { end };
                break 'label6
               }
               if p >= end { wi = 6; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 191; p = (p as usize).saturating_add(prime * 6 + 0) as *mut u8;
+              *p &= 191;
+              let p2 = p.wrapping_offset(prime_ * 6 + 0);
+              p = if p <= p2 { p2 } else { end };
               break 'label7
              }
              if p >= end { wi = 7; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 127;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 0
             }
         }
@@ -335,46 +352,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 6) < end);
                         *p.offset(prime_ * 28 + 6) &= 191;
 
-                        p = (p as usize).saturating_add(prime * 30 + 7) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 7);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 8; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 253; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+                    *p &= 253;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 1);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label9
                    }
                    if p >= end { wi = 9; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 223; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                   *p &= 223;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label10
                   }
                   if p >= end { wi = 10; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                  *p &= 239;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label11
                  }
                  if p >= end { wi = 11; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 254; p = (p as usize).saturating_add(prime * 4 + 0) as *mut u8;
+                 *p &= 254;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 0);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label12
                 }
                 if p >= end { wi = 12; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 127; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                *p &= 127;
+                let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                p = if p <= p2 { p2 } else { end };
                 break 'label13
                }
                if p >= end { wi = 13; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 247; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+               *p &= 247;
+               let p2 = p.wrapping_offset(prime_ * 4 + 1);
+               p = if p <= p2 { p2 } else { end };
                break 'label14
               }
               if p >= end { wi = 14; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 251; p = (p as usize).saturating_add(prime * 6 + 1) as *mut u8;
+              *p &= 251;
+              let p2 = p.wrapping_offset(prime_ * 6 + 1);
+              p = if p <= p2 { p2 } else { end };
               break 'label15
              }
              if p >= end { wi = 15; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 191;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 8
             }
         }
@@ -426,46 +460,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 10) < end);
                         *p.offset(prime_ * 28 + 10) &= 223;
 
-                        p = (p as usize).saturating_add(prime * 30 + 11) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 11);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 16; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 251; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+                    *p &= 251;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 2);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label17
                    }
                    if p >= end { wi = 17; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 239; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                   *p &= 239;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label18
                   }
                   if p >= end { wi = 18; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 254; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                  *p &= 254;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label19
                  }
                  if p >= end { wi = 19; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 191; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                 *p &= 191;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label20
                 }
                 if p >= end { wi = 20; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 253; p = (p as usize).saturating_add(prime * 2 + 0) as *mut u8;
+                *p &= 253;
+                let p2 = p.wrapping_offset(prime_ * 2 + 0);
+                p = if p <= p2 { p2 } else { end };
                 break 'label21
                }
                if p >= end { wi = 21; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 127; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+               *p &= 127;
+               let p2 = p.wrapping_offset(prime_ * 4 + 2);
+               p = if p <= p2 { p2 } else { end };
                break 'label22
               }
               if p >= end { wi = 22; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 247; p = (p as usize).saturating_add(prime * 6 + 2) as *mut u8;
+              *p &= 247;
+              let p2 = p.wrapping_offset(prime_ * 6 + 2);
+              p = if p <= p2 { p2 } else { end };
               break 'label23
              }
              if p >= end { wi = 23; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 223;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 16
             }
         }
@@ -517,46 +568,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 12) < end);
                         *p.offset(prime_ * 28 + 12) &= 239;
 
-                        p = (p as usize).saturating_add(prime * 30 + 13) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 13);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 24; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 247; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                    *p &= 247;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label25
                    }
                    if p >= end { wi = 25; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 254; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+                   *p &= 254;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 1);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label26
                   }
                   if p >= end { wi = 26; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 191; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                  *p &= 191;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label27
                  }
                  if p >= end { wi = 27; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 223; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                 *p &= 223;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label28
                 }
                 if p >= end { wi = 28; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                *p &= 251;
+                let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                p = if p <= p2 { p2 } else { end };
                 break 'label29
                }
                if p >= end { wi = 29; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 253; p = (p as usize).saturating_add(prime * 4 + 1) as *mut u8;
+               *p &= 253;
+               let p2 = p.wrapping_offset(prime_ * 4 + 1);
+               p = if p <= p2 { p2 } else { end };
                break 'label30
               }
               if p >= end { wi = 30; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 127; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+              *p &= 127;
+              let p2 = p.wrapping_offset(prime_ * 6 + 3);
+              p = if p <= p2 { p2 } else { end };
               break 'label31
              }
              if p >= end { wi = 31; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 239; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 239;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 24
             }
         }
@@ -608,46 +676,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 16) < end);
                         *p.offset(prime_ * 28 + 16) &= 247;
 
-                        p = (p as usize).saturating_add(prime * 30 + 17) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 17);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 32; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 239; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+                    *p &= 239;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 3);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label33
                    }
                    if p >= end { wi = 33; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 127; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                   *p &= 127;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label34
                   }
                   if p >= end { wi = 34; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                  *p &= 253;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label35
                  }
                  if p >= end { wi = 35; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 251; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                 *p &= 251;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label36
                 }
                 if p >= end { wi = 36; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 223; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                *p &= 223;
+                let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                p = if p <= p2 { p2 } else { end };
                 break 'label37
                }
                if p >= end { wi = 37; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 191; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+               *p &= 191;
+               let p2 = p.wrapping_offset(prime_ * 4 + 3);
+               p = if p <= p2 { p2 } else { end };
                break 'label38
               }
               if p >= end { wi = 38; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 254; p = (p as usize).saturating_add(prime * 6 + 3) as *mut u8;
+              *p &= 254;
+              let p2 = p.wrapping_offset(prime_ * 6 + 3);
+              p = if p <= p2 { p2 } else { end };
               break 'label39
              }
              if p >= end { wi = 39; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 247;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 32
             }
         }
@@ -699,46 +784,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 18) < end);
                         *p.offset(prime_ * 28 + 18) &= 251;
 
-                        p = (p as usize).saturating_add(prime * 30 + 19) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 19);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 40; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 223; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+                    *p &= 223;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 4);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label41
                    }
                    if p >= end { wi = 41; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 247; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                   *p &= 247;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label42
                   }
                   if p >= end { wi = 42; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 127; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                  *p &= 127;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label43
                  }
                  if p >= end { wi = 43; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 253; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+                 *p &= 253;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 2);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label44
                 }
                 if p >= end { wi = 44; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 191; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                *p &= 191;
+                let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                p = if p <= p2 { p2 } else { end };
                 break 'label45
                }
                if p >= end { wi = 45; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 254; p = (p as usize).saturating_add(prime * 4 + 2) as *mut u8;
+               *p &= 254;
+               let p2 = p.wrapping_offset(prime_ * 4 + 2);
+               p = if p <= p2 { p2 } else { end };
                break 'label46
               }
               if p >= end { wi = 46; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 239; p = (p as usize).saturating_add(prime * 6 + 4) as *mut u8;
+              *p &= 239;
+              let p2 = p.wrapping_offset(prime_ * 6 + 4);
+              p = if p <= p2 { p2 } else { end };
               break 'label47
              }
              if p >= end { wi = 47; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 251; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 251;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 40
             }
         }
@@ -790,46 +892,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 22) < end);
                         *p.offset(prime_ * 28 + 22) &= 253;
 
-                        p = (p as usize).saturating_add(prime * 30 + 23) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 23);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 48; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 191; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+                    *p &= 191;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 5);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label49
                    }
                    if p >= end { wi = 49; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 251; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+                   *p &= 251;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 3);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label50
                   }
                   if p >= end { wi = 50; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 247; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                  *p &= 247;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label51
                  }
                  if p >= end { wi = 51; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 127; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                 *p &= 127;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label52
                 }
                 if p >= end { wi = 52; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+                *p &= 254;
+                let p2 = p.wrapping_offset(prime_ * 2 + 1);
+                p = if p <= p2 { p2 } else { end };
                 break 'label53
                }
                if p >= end { wi = 53; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 239; p = (p as usize).saturating_add(prime * 4 + 3) as *mut u8;
+               *p &= 239;
+               let p2 = p.wrapping_offset(prime_ * 4 + 3);
+               p = if p <= p2 { p2 } else { end };
                break 'label54
               }
               if p >= end { wi = 54; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 223; p = (p as usize).saturating_add(prime * 6 + 5) as *mut u8;
+              *p &= 223;
+              let p2 = p.wrapping_offset(prime_ * 6 + 5);
+              p = if p <= p2 { p2 } else { end };
               break 'label55
              }
              if p >= end { wi = 55; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 253; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 253;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 48
             }
         }
@@ -881,46 +1000,63 @@ pub unsafe fn hardcoded_sieve(bytes: &mut [u8], si_: &mut usize, wi_: &mut usize
                                      p.wrapping_offset(prime_ * 28 + 28) < end);
                         *p.offset(prime_ * 28 + 28) &= 254;
 
-                        p = (p as usize).saturating_add(prime * 30 + 29) as *mut u8;
+                        let p2 = p.wrapping_offset(prime_ * 30 + 29);
+                        p = if p <= p2 { p2 } else { end };
                     }
                     if p >= end { wi = 56; break 'outer; }
                     safe_assert!(start <= p && p < end);
-                    *p &= 127; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+                    *p &= 127;
+                    let p2 = p.wrapping_offset(prime_ * 6 + 6);
+                    p = if p <= p2 { p2 } else { end };
                     break 'label57
                    }
                    if p >= end { wi = 57; break 'outer; }
                    safe_assert!(start <= p && p < end);
-                   *p &= 191; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                   *p &= 191;
+                   let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                   p = if p <= p2 { p2 } else { end };
                    break 'label58
                   }
                   if p >= end { wi = 58; break 'outer; }
                   safe_assert!(start <= p && p < end);
-                  *p &= 223; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                  *p &= 223;
+                  let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                  p = if p <= p2 { p2 } else { end };
                   break 'label59
                  }
                  if p >= end { wi = 59; break 'outer; }
                  safe_assert!(start <= p && p < end);
-                 *p &= 239; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+                 *p &= 239;
+                 let p2 = p.wrapping_offset(prime_ * 4 + 4);
+                 p = if p <= p2 { p2 } else { end };
                  break 'label60
                 }
                 if p >= end { wi = 60; break 'outer; }
                 safe_assert!(start <= p && p < end);
-                *p &= 247; p = (p as usize).saturating_add(prime * 2 + 2) as *mut u8;
+                *p &= 247;
+                let p2 = p.wrapping_offset(prime_ * 2 + 2);
+                p = if p <= p2 { p2 } else { end };
                 break 'label61
                }
                if p >= end { wi = 61; break 'outer; }
                safe_assert!(start <= p && p < end);
-               *p &= 251; p = (p as usize).saturating_add(prime * 4 + 4) as *mut u8;
+               *p &= 251;
+               let p2 = p.wrapping_offset(prime_ * 4 + 4);
+               p = if p <= p2 { p2 } else { end };
                break 'label62
               }
               if p >= end { wi = 62; break 'outer; }
               safe_assert!(start <= p && p < end);
-              *p &= 253; p = (p as usize).saturating_add(prime * 6 + 6) as *mut u8;
+              *p &= 253;
+              let p2 = p.wrapping_offset(prime_ * 6 + 6);
+              p = if p <= p2 { p2 } else { end };
               break 'label63
              }
              if p >= end { wi = 63; break 'outer; }
              safe_assert!(start <= p && p < end);
-             *p &= 254; p = (p as usize).saturating_add(prime * 2 + 1) as *mut u8;
+             *p &= 254;
+             let p2 = p.wrapping_offset(prime_ * 2 + 1);
+             p = if p <= p2 { p2 } else { end };
              wi = 56
             }
         }

--- a/primal-slowsieve/Cargo.toml
+++ b/primal-slowsieve/Cargo.toml
@@ -20,7 +20,7 @@ primal-bit = { path = "../primal-bit", version = "0.3" }
 primal-estimate = { path = "../primal-estimate", version = "0.3" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.3.4", features = ["html_reports"] }
 
 [[bench]]
 name = "bench"

--- a/primal-slowsieve/benches/bench.rs
+++ b/primal-slowsieve/benches/bench.rs
@@ -1,26 +1,30 @@
 #[macro_use]
 extern crate criterion;
 
-use primal_slowsieve::Primes;
 use criterion::Criterion;
+use primal_slowsieve::Primes;
 
 const SIZES: [usize; 4] = [100, 10_000, 100_000, 1_000_000];
 
 fn sieve(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "Primes::sieve",
-        |b, upto: &&usize| b.iter(|| Primes::sieve(**upto)),
-        &SIZES);
+    let mut group = c.benchmark_group("Primes::sieve");
+    for i in &SIZES {
+        group.bench_with_input(i.to_string(), i, |b, upto: &usize| {
+            b.iter(|| Primes::sieve(*upto))
+        });
+    }
+    group.finish();
 }
 
 fn primes(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "Primes::primes",
-        |b, upto: &&usize| {
-            let s = Primes::sieve(**upto);
+    let mut group = c.benchmark_group("Primes::primes");
+    for i in &SIZES {
+        group.bench_with_input(i.to_string(), i, |b, upto: &usize| {
+            let s = Primes::sieve(*upto);
             b.iter(|| s.primes().count())
-        },
-        &SIZES);
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(benches, sieve, primes);


### PR DESCRIPTION
We must not use `pointer::offset` when the result may be out of bounds.

- In the `safe_assert!` checks, use `wrapping_offset`. We're comparing
  to both start and end pointers, so it can handle overflowing the end or even
  wrapping around less than start.
- For other updates, use `wrapping_offset` and assign `end` if it did wrap,
  so further code only has to check it against the end pointer.

Fixes #35.

I've also included a few minor updates and a release bump:

- Use panic formatting in a test to avoid a deprecation
- Release primal-sieve 0.3.2
- Migrate from criterion deprecations
