### PR TITLE
Revert "Temporarily ignore i686 bench"

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -19,11 +19,7 @@ fi
 
 $cargo build -v --all $target_param --features "$features"
 $cargo test -v --all $target_param --features "$features"
-# Temporarily ignoring bench on other targets due to an i686 regression in rustc
-# https://github.com/rust-lang/rust/issues/94032
-if [ -z "$TARGET" ]; then
-    $cargo bench -v --all $target_param --features "$features" -- --test # don't actually record numbers
-fi
+$cargo bench -v --all $target_param --features "$features" -- --test # don't actually record numbers
 $cargo doc -v --all $target_param --features "$features"
 
 $cargo test -v -p primal-sieve --features "$features primal-sieve/safe"


### PR DESCRIPTION
This reverts commit 9da74e7c973e69e2338d761ae785ca3dee5532b1.

The codegen issue was fixed by updates to LLVM 14, rust-lang/rust#94764.
