### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 homepage = "https://github.com/huonw/primal"
 repository = "https://github.com/huonw/primal"
-documentation = "http://docs.rs/primal/"
+documentation = "https://docs.rs/primal/"
 license = "MIT OR Apache-2.0"
 keywords = ["math", "mathematics", "primes", "number-theory"]
 readme = "README.md"

--- a/primal-bit/Cargo.toml
+++ b/primal-bit/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 homepage = "https://github.com/huonw/primal"
 repository = "https://github.com/huonw/primal"
-documentation = "http://docs.rs/primal-bit/"
+documentation = "https://docs.rs/primal-bit/"
 license = "MIT OR Apache-2.0"
 keywords = ["math", "mathematics", "primes", "number-theory"]
 

--- a/primal-check/Cargo.toml
+++ b/primal-check/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 homepage = "https://github.com/huonw/primal"
 repository = "https://github.com/huonw/primal"
-documentation = "http://docs.rs/primal-check/"
+documentation = "https://docs.rs/primal-check/"
 license = "MIT OR Apache-2.0"
 keywords = ["math", "mathematics", "primes", "number-theory"]
 

--- a/primal-estimate/Cargo.toml
+++ b/primal-estimate/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 homepage = "https://github.com/huonw/primal"
 repository = "https://github.com/huonw/primal"
-documentation = "http://docs.rs/primal-estimate/"
+documentation = "https://docs.rs/primal-estimate/"
 license = "MIT OR Apache-2.0"
 keywords = ["math", "mathematics", "primes", "number-theory"]
 description = """

--- a/primal-sieve/Cargo.toml
+++ b/primal-sieve/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 homepage = "https://github.com/huonw/primal"
 repository = "https://github.com/huonw/primal"
-documentation = "http://docs.rs/primal-sieve/"
+documentation = "https://docs.rs/primal-sieve/"
 license = "MIT OR Apache-2.0"
 keywords = ["math", "mathematics", "primes", "number-theory"]
 

--- a/primal-slowsieve/Cargo.toml
+++ b/primal-slowsieve/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 homepage = "https://github.com/huonw/primal"
 repository = "https://github.com/huonw/primal"
-documentation = "http://docs.rs/primal-slowsieve/"
+documentation = "https://docs.rs/primal-slowsieve/"
 license = "MIT OR Apache-2.0"
 keywords = ["math", "mathematics", "primes", "number-theory"]
 


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `Cargo.toml`:
 - `http://docs.rs/primal/` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `primal-bit/Cargo.toml`:
 - `http://docs.rs/primal-bit/` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `primal-sieve/Cargo.toml`:
 - `http://docs.rs/primal-sieve/` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `primal-estimate/Cargo.toml`:
 - `http://docs.rs/primal-estimate/` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `primal-slowsieve/Cargo.toml`:
 - `http://docs.rs/primal-slowsieve/` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `primal-check/Cargo.toml`:
 - `http://docs.rs/primal-check/` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

