### PR TITLE
Release new versions of all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "primal"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -6,13 +6,13 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.139 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.155 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -28,12 +28,12 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-automata 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -61,7 +61,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -76,17 +76,17 @@ dependencies = [
  "csv 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "oorandom 11.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "plotters 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -122,12 +122,12 @@ name = "crossbeam-epoch"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -145,15 +145,15 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bstr 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -187,23 +187,20 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.139 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.155 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.139 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -213,15 +210,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -231,16 +228,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memchr"
@@ -252,33 +246,32 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.139 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.155 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -296,11 +289,11 @@ name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "plotters-backend 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plotters-svg 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -338,7 +331,7 @@ dependencies = [
 name = "primal-check"
 version = "0.3.4"
 dependencies = [
- "num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "primal 0.3.3",
 ]
 
@@ -358,7 +351,7 @@ dependencies = [
  "primal-bit 0.3.2",
  "primal-estimate 0.3.3",
  "primal-slowsieve 0.3.2",
- "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -372,18 +365,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-ident 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -391,9 +384,9 @@ name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon-core 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -405,15 +398,15 @@ dependencies = [
  "crossbeam-channel 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex-syntax 0.6.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -423,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -431,12 +424,12 @@ name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "semver 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -444,22 +437,22 @@ name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -468,42 +461,52 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "half 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.107 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-ident 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -511,7 +514,7 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -519,86 +522,85 @@ name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 3.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.107 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.107 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -617,10 +619,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows-sys 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -628,12 +630,75 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "windows-targets 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_aarch64_msvc 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnu 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnullvm 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_msvc 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnu 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnullvm 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_msvc 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-"checksum autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+"checksum autocfg 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bstr 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
-"checksum bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+"checksum bumpalo 3.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 "checksum cast 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 "checksum cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 "checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -645,59 +710,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-epoch 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 "checksum crossbeam-utils 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 "checksum csv 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-"checksum csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-"checksum either 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+"checksum csv-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+"checksum either 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 "checksum half 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 "checksum hamming 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65043da274378d68241eb9a8f8f8aa54e349136f7b8e12f63e3ef44043cc30e1"
 "checksum hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-"checksum hermit-abi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+"checksum hermit-abi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 "checksum itertools 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 "checksum itoa 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-"checksum itoa 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
-"checksum js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)" = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+"checksum itoa 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+"checksum js-sys 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)" = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.139 (registry+https://github.com/rust-lang/crates.io-index)" = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
-"checksum log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+"checksum libc 0.2.155 (registry+https://github.com/rust-lang/crates.io-index)" = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+"checksum log 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)" = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 "checksum memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 "checksum memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-"checksum num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)" = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-"checksum num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-"checksum num_cpus 1.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+"checksum num-integer 0.1.46 (registry+https://github.com/rust-lang/crates.io-index)" = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+"checksum num-traits 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+"checksum num_cpus 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 "checksum once_cell 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 "checksum oorandom 11.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 "checksum plotters 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 "checksum plotters-backend 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
 "checksum plotters-svg 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
-"checksum proc-macro2 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)" = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
-"checksum quote 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+"checksum proc-macro2 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)" = "92de25114670a878b1261c79c9f8f729fb97e95bac93f6312f583c60dd6a1dfe"
+"checksum quote 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 "checksum rayon 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 "checksum rayon-core 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
-"checksum regex 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+"checksum regex 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 "checksum regex-automata 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-"checksum regex-syntax 0.6.28 (registry+https://github.com/rust-lang/crates.io-index)" = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+"checksum regex-syntax 0.6.29 (registry+https://github.com/rust-lang/crates.io-index)" = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 "checksum rustc_version 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-"checksum ryu 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+"checksum ryu 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-"checksum semver 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
-"checksum serde 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)" = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+"checksum scopeguard 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+"checksum semver 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+"checksum serde 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)" = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 "checksum serde_cbor 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-"checksum serde_derive 1.0.152 (registry+https://github.com/rust-lang/crates.io-index)" = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
-"checksum serde_json 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
-"checksum smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-"checksum syn 1.0.107 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+"checksum serde_derive 1.0.156 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+"checksum serde_json 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+"checksum smallvec 1.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+"checksum syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)" = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+"checksum syn 2.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum tinytemplate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-"checksum unicode-ident 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-"checksum unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-"checksum walkdir 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-"checksum wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
-"checksum wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
-"checksum wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
-"checksum wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
-"checksum wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
-"checksum web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)" = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+"checksum unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+"checksum unicode-width 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+"checksum walkdir 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+"checksum wasm-bindgen 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)" = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+"checksum wasm-bindgen-backend 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)" = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+"checksum wasm-bindgen-macro 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)" = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+"checksum wasm-bindgen-macro-support 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)" = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+"checksum wasm-bindgen-shared 0.2.92 (registry+https://github.com/rust-lang/crates.io-index)" = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+"checksum web-sys 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)" = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+"checksum winapi-util 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum windows-sys 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+"checksum windows-targets 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+"checksum windows_aarch64_gnullvm 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+"checksum windows_aarch64_msvc 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+"checksum windows_i686_gnu 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+"checksum windows_i686_gnullvm 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+"checksum windows_i686_msvc 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+"checksum windows_x86_64_gnu 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+"checksum windows_x86_64_gnullvm 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+"checksum windows_x86_64_msvc 0.52.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -168,8 +168,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "generators"
 version = "0.3.0"
 dependencies = [
- "primal-check 0.3.3",
- "primal-slowsieve 0.3.1",
+ "primal-check 0.3.4",
+ "primal-slowsieve 0.3.2",
 ]
 
 [[package]]
@@ -318,56 +318,56 @@ dependencies = [
 
 [[package]]
 name = "primal"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "primal-check 0.3.3",
- "primal-estimate 0.3.2",
- "primal-sieve 0.3.6",
- "primal-slowsieve 0.3.1",
+ "primal-check 0.3.4",
+ "primal-estimate 0.3.3",
+ "primal-sieve 0.3.7",
+ "primal-slowsieve 0.3.2",
 ]
 
 [[package]]
 name = "primal-bit"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hamming 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "primal-check"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "primal 0.3.2",
+ "primal 0.3.3",
 ]
 
 [[package]]
 name = "primal-estimate"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
- "primal 0.3.2",
+ "primal 0.3.3",
 ]
 
 [[package]]
 name = "primal-sieve"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "criterion 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "primal 0.3.2",
- "primal-bit 0.3.1",
- "primal-estimate 0.3.2",
- "primal-slowsieve 0.3.1",
+ "primal 0.3.3",
+ "primal-bit 0.3.2",
+ "primal-estimate 0.3.3",
+ "primal-slowsieve 0.3.2",
  "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "primal-slowsieve"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "primal-bit 0.3.1",
- "primal-estimate 0.3.2",
+ "primal-bit 0.3.2",
+ "primal-estimate 0.3.3",
 ]
 
 [[package]]

--- a/primal-bit/Cargo.toml
+++ b/primal-bit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-bit"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Huon Wilson <dbau.pp@gmail.com>",
            "The Rust Project Developers"]
 edition = "2018"

--- a/primal-check/Cargo.toml
+++ b/primal-check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-check"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 

--- a/primal-estimate/Cargo.toml
+++ b/primal-estimate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-estimate"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 

--- a/primal-sieve/Cargo.toml
+++ b/primal-sieve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-sieve"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 

--- a/primal-slowsieve/Cargo.toml
+++ b/primal-slowsieve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primal-slowsieve"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Every crate had its doc link updated in #57, and `primal-sieve` also got a fix in #61.